### PR TITLE
feat: Added `From` implementation for `Value` for inner types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Released on ??
 - Added `FromStr`, `From<&str>`, and `From<String>` implementations for `Value`, which automatically builds a
   `Value::Text`
   variant when converting from string types.
+- [Added `From` implementation for `Value` for inner types]((https://github.com/veeso/ic-dbms/pull/18): `i8`, `i16`,
+  `i32`, `i64`, `u8`, `u16`, `u32`, `u64`,
+  `&[u8]`, `Vec<u8>`, `Principal`, `rust_decimal::Decimal`, `Uuid`, which
+  automatically builds the corresponding `Value` variant when converting from these types.
 
 ## 0.2.0
 


### PR DESCRIPTION
e.g. `u8` to `Value::Uint8`, `rust_decimal::Decimal` to `Value::Decimal`

closes #14

