### PR TITLE
feat: derive Default on generated *UpdateRequest structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.8.2
+
+Released on 2026-04-21
+
+### Changed
+
+- derive `Default` on generated `*UpdateRequest` structs
+  > All fields on update requests are `Option<T>`, so `Default` is always
+  > derivable. This enables the `..Default::default()` struct-update pattern
+  > when constructing partial updates, removing the need to write `None`
+  > for every untouched field.
+
 ## 0.8.1
 
 Released on 2026-04-05

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 rust-version = "1.91.1"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]

--- a/crates/ic-dbms/ic-dbms-canister/src/tests/user.rs
+++ b/crates/ic-dbms/ic-dbms-canister/src/tests/user.rs
@@ -42,4 +42,14 @@ mod tests {
         let fingerprint = User::fingerprint();
         assert_ne!(fingerprint, 0);
     }
+
+    #[test]
+    fn test_update_request_default_all_none() {
+        let patch = super::UserUpdateRequest::default();
+        assert!(patch.id.is_none());
+        assert!(patch.name.is_none());
+        assert!(patch.email.is_none());
+        assert!(patch.age.is_none());
+        assert!(patch.where_clause.is_none());
+    }
 }

--- a/crates/wasm-dbms/wasm-dbms-macros/src/table/update.rs
+++ b/crates/wasm-dbms/wasm-dbms-macros/src/table/update.rs
@@ -48,11 +48,11 @@ fn generate_update_request_struct(metadata: &TableMetadata) -> TokenStream2 {
 
     let derives = if metadata.candid {
         quote::quote! {
-            #[derive(Clone, candid::CandidType, serde::Serialize, serde::Deserialize)]
+            #[derive(Clone, Default, candid::CandidType, serde::Serialize, serde::Deserialize)]
         }
     } else {
         quote::quote! {
-            #[derive(Clone)]
+            #[derive(Clone, Default)]
         }
     };
 

--- a/crates/wasm-dbms/wasm-dbms/src/database/tests.rs
+++ b/crates/wasm-dbms/wasm-dbms/src/database/tests.rs
@@ -323,6 +323,34 @@ fn test_update_no_matching_records() {
     assert_eq!(count, 0);
 }
 
+#[test]
+fn test_update_request_default_all_none() {
+    let patch = UserUpdateRequest::default();
+    assert!(patch.id.is_none());
+    assert!(patch.name.is_none());
+    assert!(patch.where_clause.is_none());
+    assert!(patch.update_values().is_empty());
+    assert!(patch.where_clause().is_none());
+}
+
+#[test]
+fn test_update_request_default_with_struct_update() {
+    let ctx = setup();
+    let db = WasmDbmsDatabase::oneshot(&ctx, TestSchema);
+    insert_user(&db, 1, "alice");
+
+    let patch = UserUpdateRequest {
+        name: Some(Text("alicia".to_string())),
+        where_clause: Some(Filter::eq("id", Value::Uint32(Uint32(1)))),
+        ..Default::default()
+    };
+    let count = db.update::<User>(patch).unwrap();
+    assert_eq!(count, 1);
+
+    let rows = db.select::<User>(Query::builder().build()).unwrap();
+    assert_eq!(rows[0].name, Some(Text("alicia".to_string())));
+}
+
 // -- delete operations --
 
 #[test]


### PR DESCRIPTION
## Summary

- Derive `Default` on generated `*UpdateRequest` structs (both candid and plain variants). All fields are `Option<T>` so `Default` is always derivable, enabling the `..Default::default()` struct-update pattern for partial updates.
- Bump workspace version to `0.8.2` and update CHANGELOG.

## Test plan

- [x] `cargo test -p wasm-dbms` — new `test_update_request_default_all_none` and `test_update_request_default_with_struct_update` pass
- [x] `cargo test -p ic-dbms-canister` — new `test_update_request_default_all_none` passes for candid variant
- [x] `just clippy` clean
- [x] `just fmt_nightly` applied