### PR TITLE
feat(query): add DISTINCT support to query API

### DIFF
--- a/crates/wasm-dbms/wasm-dbms-api/src/dbms/query.rs
+++ b/crates/wasm-dbms/wasm-dbms-api/src/dbms/query.rs
@@ -115,6 +115,8 @@ pub struct Query {
     pub joins: Vec<Join>,
     /// [`Filter`] to apply to the query.
     pub filter: Option<Filter>,
+    /// Distinct records by the specified fields.
+    pub distinct_by: Vec<String>,
     /// Order by clauses for sorting the results.
     pub order_by: Vec<(String, OrderDirection)>,
     /// Limit on the number of records to return.
@@ -132,6 +134,7 @@ impl candid::CandidType for Query {
             candid::field! { eager_relations: <Vec<String>>::_ty() },
             candid::field! { joins: <Vec<Join>>::_ty() },
             candid::field! { filter: <Option<Filter>>::_ty() },
+            candid::field! { distinct_by: <Vec<String>>::_ty() },
             candid::field! { order_by: <Vec<(String, OrderDirection)>>::_ty() },
             candid::field! { limit: <Option<usize>>::_ty() },
             candid::field! { offset: <Option<usize>>::_ty() },
@@ -154,6 +157,7 @@ impl candid::CandidType for Query {
         record_serializer.serialize_element(&self.offset)?;
         record_serializer.serialize_element(&self.limit)?;
         record_serializer.serialize_element(&self.filter)?;
+        record_serializer.serialize_element(&self.distinct_by)?;
         record_serializer.serialize_element(&self.order_by)?;
         record_serializer.serialize_element(&self.columns)?;
 

--- a/crates/wasm-dbms/wasm-dbms-api/src/dbms/query.rs
+++ b/crates/wasm-dbms/wasm-dbms-api/src/dbms/query.rs
@@ -153,11 +153,11 @@ impl candid::CandidType for Query {
         // The order is determined empirically by the Candid hash of each field name.
         let mut record_serializer = serializer.serialize_struct()?;
         record_serializer.serialize_element(&self.eager_relations)?;
+        record_serializer.serialize_element(&self.distinct_by)?;
         record_serializer.serialize_element(&self.joins)?;
         record_serializer.serialize_element(&self.offset)?;
         record_serializer.serialize_element(&self.limit)?;
         record_serializer.serialize_element(&self.filter)?;
-        record_serializer.serialize_element(&self.distinct_by)?;
         record_serializer.serialize_element(&self.order_by)?;
         record_serializer.serialize_element(&self.columns)?;
 

--- a/crates/wasm-dbms/wasm-dbms-api/src/dbms/query/builder.rs
+++ b/crates/wasm-dbms/wasm-dbms-api/src/dbms/query/builder.rs
@@ -74,6 +74,12 @@ impl QueryBuilder {
         self.join(JoinType::Full, table, left_col, right_col)
     }
 
+    /// Adds a DISTINCT clause to the query for the specified fields.
+    pub fn distinct<S: ToString>(mut self, fields: &[S]) -> Self {
+        self.query.distinct_by = fields.iter().map(|s| s.to_string()).collect();
+        self
+    }
+
     /// Adds an ascending order by clause for the specified field.
     pub fn order_by_asc(mut self, field: &str) -> Self {
         self.query
@@ -207,6 +213,16 @@ mod tests {
                 ("name".to_string(), OrderDirection::Ascending),
                 ("created_at".to_string(), OrderDirection::Descending)
             ]
+        );
+    }
+
+    #[test]
+    fn test_should_distinct_by_fields() {
+        let query_builder = QueryBuilder::default().distinct(&["name", "email"]);
+        let query = query_builder.build();
+        assert_eq!(
+            query.distinct_by,
+            vec!["name".to_string(), "email".to_string()]
         );
     }
 

--- a/crates/wasm-dbms/wasm-dbms/src/database.rs
+++ b/crates/wasm-dbms/wasm-dbms/src/database.rs
@@ -218,6 +218,34 @@ where
         filter.matches(record_values).map_err(DbmsError::from)
     }
 
+    /// Removes duplicate records based on the values of the given columns.
+    ///
+    /// Keeps the first record encountered for each distinct combination of the
+    /// values of the specified columns. Columns missing from a record are
+    /// treated as [`Value::Null`]. When `distinct_by` is empty, no records are
+    /// removed.
+    fn apply_distinct(&self, results: &mut Vec<TableColumns>, distinct_by: &[String]) {
+        if distinct_by.is_empty() {
+            return;
+        }
+        let mut seen: HashSet<Vec<Value>> = HashSet::new();
+        results.retain(|record| {
+            let key: Vec<Value> = distinct_by
+                .iter()
+                .map(|col| {
+                    Self::this_columns(record)
+                        .and_then(|cols| {
+                            cols.iter()
+                                .find(|(cd, _)| cd.name == col.as_str())
+                                .map(|(_, v)| v.clone())
+                        })
+                        .unwrap_or(Value::Null)
+                })
+                .collect();
+            seen.insert(key)
+        });
+    }
+
     /// Filters record columns down to only the selected fields.
     fn apply_column_selection<T>(&self, results: &mut [TableColumns], query: &Query)
     where
@@ -607,23 +635,26 @@ where
         };
 
         let mut results = Vec::with_capacity(query.limit.unwrap_or(DEFAULT_SELECT_CAPACITY));
-        // When ORDER BY is present, LIMIT and OFFSET must be applied after sorting
-        // to comply with standard SQL semantics (ORDER BY -> OFFSET -> LIMIT).
+        // When ORDER BY or DISTINCT is present, LIMIT and OFFSET must be applied after
+        // sorting and deduplication to comply with standard SQL semantics
+        // (WHERE -> DISTINCT -> ORDER BY -> OFFSET -> LIMIT).
         let has_order_by = !query.order_by.is_empty();
+        let has_distinct = !query.distinct_by.is_empty();
+        let defer_pagination = has_order_by || has_distinct;
         let mut count = 0;
 
         if let Some(indexed_rows) =
             self.try_index_select::<T>(&query, &table_registry, &table_overlay)?
         {
             for values in indexed_rows {
-                if !has_order_by {
+                if !defer_pagination {
                     count += 1;
                     if query.offset.is_some_and(|offset| count <= offset) {
                         continue;
                     }
                 }
                 results.push(vec![(ValuesSource::This, values)]);
-                if !has_order_by && query.limit.is_some_and(|limit| results.len() >= limit) {
+                if !defer_pagination && query.limit.is_some_and(|limit| results.len() >= limit) {
                     break;
                 }
             }
@@ -638,19 +669,20 @@ where
                 {
                     continue;
                 }
-                if !has_order_by {
+                if !defer_pagination {
                     count += 1;
                     if query.offset.is_some_and(|offset| count <= offset) {
                         continue;
                     }
                 }
                 results.push(vec![(ValuesSource::This, values)]);
-                if !has_order_by && query.limit.is_some_and(|limit| results.len() >= limit) {
+                if !defer_pagination && query.limit.is_some_and(|limit| results.len() >= limit) {
                     break;
                 }
             }
         }
 
+        self.apply_distinct(&mut results, &query.distinct_by);
         self.batch_load_eager_relations::<T>(&mut results, &query)?;
         self.apply_column_selection::<T>(&mut results, &query);
 
@@ -658,8 +690,8 @@ where
             self.sort_query_results(&mut results, &column, direction);
         }
 
-        // Apply OFFSET and LIMIT after sorting when ORDER BY was present
-        if has_order_by {
+        // Apply OFFSET and LIMIT after sorting/deduplication when deferred
+        if defer_pagination {
             let offset = query.offset.unwrap_or_default();
             if offset > 0 {
                 if offset >= results.len() {

--- a/crates/wasm-dbms/wasm-dbms/src/database/tests.rs
+++ b/crates/wasm-dbms/wasm-dbms/src/database/tests.rs
@@ -552,6 +552,227 @@ fn test_select_raw() {
     assert_eq!(rows[0][0].1, Value::Uint32(Uint32(1)));
 }
 
+// -- select with distinct --
+
+#[test]
+fn test_select_distinct_by_single_column() {
+    let ctx = setup();
+    let db = WasmDbmsDatabase::oneshot(&ctx, TestSchema);
+    insert_user(&db, 1, "alice");
+    insert_user(&db, 2, "bob");
+    insert_user(&db, 3, "alice");
+    insert_user(&db, 4, "charlie");
+    insert_user(&db, 5, "bob");
+
+    let rows = db
+        .select::<User>(
+            Query::builder()
+                .all()
+                .distinct(&["name"])
+                .order_by_asc("name")
+                .build(),
+        )
+        .unwrap();
+
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].name, Some(Text("alice".to_string())));
+    assert_eq!(rows[1].name, Some(Text("bob".to_string())));
+    assert_eq!(rows[2].name, Some(Text("charlie".to_string())));
+}
+
+#[test]
+fn test_select_distinct_keeps_first_encountered() {
+    let ctx = setup();
+    let db = WasmDbmsDatabase::oneshot(&ctx, TestSchema);
+    insert_user(&db, 1, "alice");
+    insert_user(&db, 2, "alice");
+    insert_user(&db, 3, "alice");
+
+    let rows = db
+        .select::<User>(Query::builder().all().distinct(&["name"]).build())
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, Some(Uint32(1)));
+}
+
+#[test]
+fn test_select_distinct_by_multiple_columns() {
+    let ctx = setup();
+    let db = WasmDbmsDatabase::oneshot(&ctx, TestSchema);
+    insert_user(&db, 1, "alice");
+    insert_user(&db, 2, "bob");
+    // Posts where (title, user_id) pairs deliberately duplicate.
+    insert_post(&db, 10, "hello", 1);
+    insert_post(&db, 11, "world", 1);
+    insert_post(&db, 12, "hello", 2);
+    insert_post(&db, 13, "hello", 1);
+
+    let rows = db
+        .select::<Post>(
+            Query::builder()
+                .all()
+                .distinct(&["user_id"])
+                .order_by_asc("id")
+                .build(),
+        )
+        .unwrap();
+    // Distinct by user_id alone => 2 rows (one per user).
+    assert_eq!(rows.len(), 2);
+
+    let rows = db
+        .select::<Post>(
+            Query::builder()
+                .all()
+                .distinct(&["title", "user_id"])
+                .order_by_asc("id")
+                .build(),
+        )
+        .unwrap();
+    // Distinct by (title, user_id) => 3 unique pairs:
+    // ("hello",1), ("world",1), ("hello",2). The fourth row dupes ("hello",1).
+    assert_eq!(rows.len(), 3);
+}
+
+#[test]
+fn test_select_distinct_with_no_duplicates() {
+    let ctx = setup();
+    let db = WasmDbmsDatabase::oneshot(&ctx, TestSchema);
+    insert_user(&db, 1, "alice");
+    insert_user(&db, 2, "bob");
+    insert_user(&db, 3, "charlie");
+
+    let rows = db
+        .select::<User>(Query::builder().all().distinct(&["name"]).build())
+        .unwrap();
+    assert_eq!(rows.len(), 3);
+}
+
+#[test]
+fn test_select_distinct_empty_distinct_by_is_noop() {
+    let ctx = setup();
+    let db = WasmDbmsDatabase::oneshot(&ctx, TestSchema);
+    insert_user(&db, 1, "alice");
+    insert_user(&db, 2, "alice");
+    insert_user(&db, 3, "bob");
+
+    let empty: &[&str] = &[];
+    let rows = db
+        .select::<User>(Query::builder().all().distinct(empty).build())
+        .unwrap();
+    assert_eq!(rows.len(), 3);
+}
+
+#[test]
+fn test_select_distinct_with_filter() {
+    let ctx = setup();
+    let db = WasmDbmsDatabase::oneshot(&ctx, TestSchema);
+    insert_user(&db, 1, "alice");
+    insert_user(&db, 2, "alice");
+    insert_user(&db, 3, "bob");
+    insert_user(&db, 4, "charlie");
+
+    let rows = db
+        .select::<User>(
+            Query::builder()
+                .all()
+                .and_where(Filter::ne("name", Value::Text(Text("charlie".to_string()))))
+                .distinct(&["name"])
+                .build(),
+        )
+        .unwrap();
+
+    assert_eq!(rows.len(), 2);
+    let names: Vec<_> = rows.iter().filter_map(|r| r.name.clone()).collect();
+    assert!(names.contains(&Text("alice".to_string())));
+    assert!(names.contains(&Text("bob".to_string())));
+}
+
+#[test]
+fn test_select_distinct_with_limit_and_offset() {
+    let ctx = setup();
+    let db = WasmDbmsDatabase::oneshot(&ctx, TestSchema);
+    insert_user(&db, 1, "alice");
+    insert_user(&db, 2, "alice");
+    insert_user(&db, 3, "bob");
+    insert_user(&db, 4, "charlie");
+    insert_user(&db, 5, "dave");
+
+    // 4 distinct names -> alice, bob, charlie, dave; offset 1, limit 2 -> bob, charlie
+    let rows = db
+        .select::<User>(
+            Query::builder()
+                .all()
+                .distinct(&["name"])
+                .order_by_asc("name")
+                .offset(1)
+                .limit(2)
+                .build(),
+        )
+        .unwrap();
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].name, Some(Text("bob".to_string())));
+    assert_eq!(rows[1].name, Some(Text("charlie".to_string())));
+}
+
+#[test]
+fn test_select_distinct_pagination_applies_after_dedup() {
+    let ctx = setup();
+    let db = WasmDbmsDatabase::oneshot(&ctx, TestSchema);
+    // Many duplicates; without distinct LIMIT 2 would yield duplicates.
+    insert_user(&db, 1, "alice");
+    insert_user(&db, 2, "alice");
+    insert_user(&db, 3, "alice");
+    insert_user(&db, 4, "bob");
+    insert_user(&db, 5, "bob");
+
+    let rows = db
+        .select::<User>(
+            Query::builder()
+                .all()
+                .distinct(&["name"])
+                .order_by_asc("name")
+                .limit(2)
+                .build(),
+        )
+        .unwrap();
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].name, Some(Text("alice".to_string())));
+    assert_eq!(rows[1].name, Some(Text("bob".to_string())));
+}
+
+#[test]
+fn test_select_distinct_on_unknown_column_collapses_to_one() {
+    let ctx = setup();
+    let db = WasmDbmsDatabase::oneshot(&ctx, TestSchema);
+    insert_user(&db, 1, "alice");
+    insert_user(&db, 2, "bob");
+    insert_user(&db, 3, "charlie");
+
+    // Unknown column -> all keys are Null -> every row hashes to the same key
+    let rows = db
+        .select::<User>(Query::builder().all().distinct(&["nonexistent"]).build())
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn test_select_distinct_via_select_raw() {
+    let ctx = setup();
+    let db = WasmDbmsDatabase::oneshot(&ctx, TestSchema);
+    insert_user(&db, 1, "alice");
+    insert_user(&db, 2, "alice");
+    insert_user(&db, 3, "bob");
+
+    let rows = db
+        .select_raw("users", Query::builder().all().distinct(&["name"]).build())
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+}
+
 // -- select with join returns error on typed select --
 
 #[test]

--- a/docs/guides/crud-operations.md
+++ b/docs/guides/crud-operations.md
@@ -30,11 +30,11 @@
 
 wasm-dbms provides four fundamental database operations through the `Database` trait:
 
-| Operation | Description | Returns |
-|-----------|-------------|---------|
-| **Insert** | Add a new record to a table | `Result<()>` |
-| **Select** | Query records from a table | `Result<Vec<Record>>` |
-| **Update** | Modify existing records | `Result<u64>` (affected rows) |
+| Operation  | Description                 | Returns                       |
+| ---------- | --------------------------- | ----------------------------- |
+| **Insert** | Add a new record to a table | `Result<()>`                  |
+| **Select** | Query records from a table  | `Result<Vec<Record>>`         |
+| **Update** | Modify existing records     | `Result<u64>` (affected rows) |
 | **Delete** | Remove records from a table | `Result<u64>` (affected rows) |
 
 All operations:
@@ -272,10 +272,10 @@ println!("Deleted {} record(s)", deleted);
 
 When deleting records that are referenced by foreign keys, you must specify a behavior:
 
-| Behavior | Description |
-|----------|-------------|
+| Behavior   | Description                                    |
+| ---------- | ---------------------------------------------- |
 | `Restrict` | Fail if any foreign keys reference this record |
-| `Cascade` | Delete all records that reference this record |
+| `Cascade`  | Delete all records that reference this record  |
 
 **Restrict Example:**
 
@@ -353,16 +353,16 @@ See the [Transactions Guide](./transactions.md) for comprehensive transaction do
 
 CRUD operations can fail for various reasons. Here are common errors:
 
-| Error | Cause | Operation |
-|-------|-------|-----------|
-| `PrimaryKeyConflict` | Record with same primary key exists | Insert |
+| Error                           | Cause                                                 | Operation              |
+| ------------------------------- | ----------------------------------------------------- | ---------------------- |
+| `PrimaryKeyConflict`            | Record with same primary key exists                   | Insert                 |
 | `ForeignKeyConstraintViolation` | Referenced record doesn't exist, or delete restricted | Insert, Update, Delete |
-| `BrokenForeignKeyReference` | Foreign key points to non-existent record | Insert, Update |
-| `UnknownColumn` | Invalid column name in filter or select | Select, Update, Delete |
-| `MissingNonNullableField` | Required field not provided | Insert, Update |
-| `RecordNotFound` | No record matches the criteria | Update, Delete |
-| `TransactionNotFound` | Invalid transaction ID | All |
-| `InvalidQuery` | Malformed query (e.g., invalid JSON path) | Select |
+| `BrokenForeignKeyReference`     | Foreign key points to non-existent record             | Insert, Update         |
+| `UnknownColumn`                 | Invalid column name in filter or select               | Select, Update, Delete |
+| `MissingNonNullableField`       | Required field not provided                           | Insert, Update         |
+| `RecordNotFound`                | No record matches the criteria                        | Update, Delete         |
+| `TransactionNotFound`           | Invalid transaction ID                                | All                    |
+| `InvalidQuery`                  | Malformed query (e.g., invalid JSON path)             | Select                 |
 
 **Example error handling:**
 

--- a/docs/guides/custom-data-types.md
+++ b/docs/guides/custom-data-types.md
@@ -76,17 +76,17 @@ pub struct Address {
 
 **Required traits:**
 
-| Trait | Purpose |
-|-------|---------|
-| `Clone` | Cloning values |
-| `Debug` | Debug formatting |
-| `PartialEq`, `Eq` | Equality comparison |
-| `PartialOrd`, `Ord` | Ordering (for sorting and range filters) |
-| `Hash` | Hashing (for hash-based lookups) |
-| `Default` | Default value construction |
-| `Serialize`, `Deserialize` | Serde serialization |
-| `Display` | Human-readable display (see Step 2) |
-| `Encode` | Binary encoding for storage (see Step 3) |
+| Trait                      | Purpose                                  |
+| -------------------------- | ---------------------------------------- |
+| `Clone`                    | Cloning values                           |
+| `Debug`                    | Debug formatting                         |
+| `PartialEq`, `Eq`          | Equality comparison                      |
+| `PartialOrd`, `Ord`        | Ordering (for sorting and range filters) |
+| `Hash`                     | Hashing (for hash-based lookups)         |
+| `Default`                  | Default value construction               |
+| `Serialize`, `Deserialize` | Serde serialization                      |
+| `Display`                  | Human-readable display (see Step 2)      |
+| `Encode`                   | Binary encoding for storage (see Step 3) |
 
 > **Note:** For IC canister usage, also derive `CandidType` and `Deserialize` from the `candid` crate.
 
@@ -176,11 +176,11 @@ pub struct Address {
 
 **Key `Encode` concepts:**
 
-| Constant | Description |
-|----------|-------------|
+| Constant             | Description                              |
+| -------------------- | ---------------------------------------- |
 | `DataSize::Fixed(n)` | Type always encodes to exactly `n` bytes |
-| `DataSize::Dynamic` | Encoded size varies per value |
-| `DEFAULT_ALIGNMENT` | Default memory page alignment (32 bytes) |
+| `DataSize::Dynamic`  | Encoded size varies per value            |
+| `DEFAULT_ALIGNMENT`  | Default memory page alignment (32 bytes) |
 
 ### Step 4: Implement DataType and Derive CustomDataType
 

--- a/docs/guides/get-started.md
+++ b/docs/guides/get-started.md
@@ -122,11 +122,11 @@ pub struct Post {
 
 The `Table` macro generates additional types for each table:
 
-| Generated Type | Purpose |
-|----------------|---------|
-| `UserRecord` | Full record returned from queries |
-| `UserInsertRequest` | Request type for inserting records |
-| `UserUpdateRequest` | Request type for updating records |
+| Generated Type       | Purpose                                |
+| -------------------- | -------------------------------------- |
+| `UserRecord`         | Full record returned from queries      |
+| `UserInsertRequest`  | Request type for inserting records     |
+| `UserUpdateRequest`  | Request type for updating records      |
 | `UserForeignFetcher` | Internal type for relationship loading |
 
 ---

--- a/docs/guides/querying.md
+++ b/docs/guides/querying.md
@@ -88,7 +88,7 @@ let query = Query::builder()
 A query consists of these optional components:
 
 | Component     | Method                   | Description               |
-|---------------|--------------------------|---------------------------|
+| ------------- | ------------------------ | ------------------------- |
 | Filter        | `.filter()`              | Which records to return   |
 | Select        | `.all()` or `.columns()` | Which columns to return   |
 | Order         | `.order_by()`            | Sort order                |
@@ -106,7 +106,7 @@ Filters determine which records match your query. All filters are created using 
 ### Comparison Filters
 
 | Filter         | Description           | Example                                               |
-|----------------|-----------------------|-------------------------------------------------------|
+| -------------- | --------------------- | ----------------------------------------------------- |
 | `Filter::eq()` | Equal to              | `Filter::eq("status", Value::Text("active".into()))`  |
 | `Filter::ne()` | Not equal to          | `Filter::ne("status", Value::Text("deleted".into()))` |
 | `Filter::gt()` | Greater than          | `Filter::gt("age", Value::Int32(18.into()))`          |
@@ -152,7 +152,7 @@ let filter = Filter::in_list("category_id", vec![
 Use `like` for pattern matching with wildcards:
 
 | Pattern | Matches                    |
-|---------|----------------------------|
+| ------- | -------------------------- |
 | `%`     | Any sequence of characters |
 | `_`     | Any single character       |
 | `%%`    | Literal `%` character      |
@@ -485,12 +485,12 @@ Joins combine rows from two or more tables based on a related column, producing 
 
 ### Join Types
 
-| Type | Builder Method | Description |
-|------|---------------|-------------|
-| INNER | `.inner_join()` | Returns only rows where both sides match |
-| LEFT | `.left_join()` | Returns all left rows; unmatched right columns are NULL |
-| RIGHT | `.right_join()` | Returns all right rows; unmatched left columns are NULL |
-| FULL | `.full_join()` | Returns all rows from both sides; unmatched columns are NULL |
+| Type  | Builder Method  | Description                                                  |
+| ----- | --------------- | ------------------------------------------------------------ |
+| INNER | `.inner_join()` | Returns only rows where both sides match                     |
+| LEFT  | `.left_join()`  | Returns all left rows; unmatched right columns are NULL      |
+| RIGHT | `.right_join()` | Returns all right rows; unmatched left columns are NULL      |
+| FULL  | `.full_join()`  | Returns all rows from both sides; unmatched columns are NULL |
 
 ### Basic Join
 
@@ -585,13 +585,13 @@ Unqualified names default to the FROM table (the table passed to `select_join`).
 
 ### Joins vs Eager Loading
 
-| | Eager Loading | Joins |
-|--|--------------|-------|
-| **Result type** | Typed (`Vec<T>`) | Untyped (`Vec<Vec<(JoinColumnDef, Value)>>`) |
-| **Result format** | Separate related records | Flat combined rows |
-| **API method** | `select::<T>` | `select_join` |
-| **Column disambiguation** | Not needed | Use `table.column` syntax |
-| **Use case** | Load parent with children | Correlate columns across tables |
+|                           | Eager Loading             | Joins                                        |
+| ------------------------- | ------------------------- | -------------------------------------------- |
+| **Result type**           | Typed (`Vec<T>`)          | Untyped (`Vec<Vec<(JoinColumnDef, Value)>>`) |
+| **Result format**         | Separate related records  | Flat combined rows                           |
+| **API method**            | `select::<T>`             | `select_join`                                |
+| **Column disambiguation** | Not needed                | Use `table.column` syntax                    |
+| **Use case**              | Load parent with children | Correlate columns across tables              |
 
 Use **eager loading** when you want typed results with related records attached. Use **joins** when you need a flat, cross-table result set -- for example, for reporting, search, or when you need columns from multiple tables in a single row.
 
@@ -633,15 +633,15 @@ let users = database.select::<User>(query)?;
 The filter analyzer extracts an index plan from the leftmost AND-chain of conditions on
 indexed columns:
 
-| Filter | Index plan | Notes |
-|--------|-----------|-------|
-| `Filter::eq("col", val)` | Exact match | Best case — direct B-tree lookup |
-| `Filter::ge("col", val)` | Range scan (start bound) | Uses linked-leaf traversal |
-| `Filter::le("col", val)` | Range scan (end bound) | Uses linked-leaf traversal |
-| `Filter::gt("col", val)` | Range scan + residual | Range is inclusive, so GT is rechecked |
-| `Filter::lt("col", val)` | Range scan + residual | Range is inclusive, so LT is rechecked |
-| `Filter::in_list("col", vals)` | Multi-lookup | One exact match per value |
-| AND of range filters on same column | Merged range | e.g., `age >= 18 AND age <= 65` |
+| Filter                              | Index plan               | Notes                                  |
+| ----------------------------------- | ------------------------ | -------------------------------------- |
+| `Filter::eq("col", val)`            | Exact match              | Best case — direct B-tree lookup       |
+| `Filter::ge("col", val)`            | Range scan (start bound) | Uses linked-leaf traversal             |
+| `Filter::le("col", val)`            | Range scan (end bound)   | Uses linked-leaf traversal             |
+| `Filter::gt("col", val)`            | Range scan + residual    | Range is inclusive, so GT is rechecked |
+| `Filter::lt("col", val)`            | Range scan + residual    | Range is inclusive, so LT is rechecked |
+| `Filter::in_list("col", vals)`      | Multi-lookup             | One exact match per value              |
+| AND of range filters on same column | Merged range             | e.g., `age >= 18 AND age <= 65`        |
 
 **Filters that fall back to full scan:**
 

--- a/docs/guides/querying.md
+++ b/docs/guides/querying.md
@@ -23,6 +23,11 @@
     - [Select All Fields](#select-all-fields)
     - [Select Specific Fields](#select-specific-fields)
   - [Eager Loading](#eager-loading)
+  - [Distinct](#distinct)
+    - [Basic Distinct](#basic-distinct)
+    - [Distinct by Multiple Columns](#distinct-by-multiple-columns)
+    - [Distinct with Ordering and Pagination](#distinct-with-ordering-and-pagination)
+    - [Distinct Semantics](#distinct-semantics)
   - [Joins](#joins)
     - [Join Types](#join-types)
     - [Basic Join](#basic-join)
@@ -30,11 +35,11 @@
     - [Chaining Multiple Joins](#chaining-multiple-joins)
     - [Qualified Column Names](#qualified-column-names)
     - [Joins vs Eager Loading](#joins-vs-eager-loading)
-- [Index-Accelerated Queries](#index-accelerated-queries)
-  - [How Indexes Improve Queries](#how-indexes-improve-queries)
-  - [Which Filters Use Indexes](#which-filters-use-indexes)
-  - [Residual Filters](#residual-filters)
-  - [Transaction-Aware Lookups](#transaction-aware-lookups)
+  - [Index-Accelerated Queries](#index-accelerated-queries)
+    - [How Indexes Improve Queries](#how-indexes-improve-queries)
+    - [Which Filters Use Indexes](#which-filters-use-indexes)
+    - [Residual Filters](#residual-filters)
+    - [Transaction-Aware Lookups](#transaction-aware-lookups)
 
 ---
 
@@ -406,6 +411,72 @@ See the [Relationships Guide](./relationships.md) for more on eager loading.
 
 ---
 
+## Distinct
+
+Use `.distinct(&[...])` to remove duplicate rows from the result set based on
+one or more columns. Rows are deduplicated by the tuple of values across the
+listed columns; the first row encountered for each distinct tuple is kept.
+
+### Basic Distinct
+
+```rust
+// Get the unique set of names from the users table
+let query = Query::builder()
+    .all()
+    .distinct(&["name"])
+    .build();
+
+let users = database.select::<User>(query)?;
+```
+
+### Distinct by Multiple Columns
+
+```rust
+// Unique (category, vendor) pairs from products
+let query = Query::builder()
+    .all()
+    .distinct(&["category", "vendor"])
+    .build();
+
+let products = database.select::<Product>(query)?;
+```
+
+### Distinct with Ordering and Pagination
+
+`DISTINCT` runs before `ORDER BY`, `OFFSET`, and `LIMIT`, so paging through
+distinct values works as expected:
+
+```rust
+// Page 2 (size 10) of unique names, alphabetical
+let query = Query::builder()
+    .all()
+    .distinct(&["name"])
+    .order_by_asc("name")
+    .offset(10)
+    .limit(10)
+    .build();
+```
+
+Without `DISTINCT`, `LIMIT 10` could yield ten copies of the same name. With
+`DISTINCT`, the limit applies to the deduplicated stream.
+
+### Distinct Semantics
+
+- Lookup is performed against the source row's columns. The columns named in
+  `.distinct(...)` do **not** need to be in the field selection.
+- A column not present on the row is treated as `Value::Null`. Listing an
+  unknown column collapses every row into a single result.
+- Calling `.distinct(&[])` (or omitting it) is a no-op.
+- Pipeline order: `WHERE` -> `DISTINCT` -> eager loading -> column selection
+  -> `ORDER BY` -> `OFFSET` / `LIMIT`. See the
+  [Query API Reference](../reference/query.md#execution-order) for the full
+  pipeline.
+
+> **Tip:** `distinct(&[pk_column])` returns at most one row per primary key,
+> which can be useful when joining sources that fan out the parent rows.
+
+---
+
 ## Joins
 
 Joins combine rows from two or more tables based on a related column, producing a single result set with columns from all joined tables. Use joins when you need to correlate data across tables in a single flat result -- for example, listing posts alongside their author names.
@@ -504,6 +575,7 @@ let query = Query::builder()
 ```
 
 Qualified names (`table.column`) work in:
+
 - Field selection (`.field()`)
 - Filters (`.and_where()`, `.or_where()`)
 - Ordering (`.order_by_asc()`, `.order_by_desc()`)

--- a/docs/guides/relationships.md
+++ b/docs/guides/relationships.md
@@ -56,11 +56,11 @@ pub struct Post {
 
 **Attribute parameters:**
 
-| Parameter | Description |
-|-----------|-------------|
-| `entity` | The Rust struct name of the referenced table |
-| `table` | The table name (as specified in `#[table = "..."]`) |
-| `column` | The column in the referenced table (usually the primary key) |
+| Parameter | Description                                                  |
+| --------- | ------------------------------------------------------------ |
+| `entity`  | The Rust struct name of the referenced table                 |
+| `table`   | The table name (as specified in `#[table = "..."]`)          |
+| `column`  | The column in the referenced table (usually the primary key) |
 
 ### Foreign Key Constraints
 
@@ -201,13 +201,13 @@ database.delete::<User>(
 
 ### Choosing a Delete Behavior
 
-| Scenario | Recommended Behavior |
-|----------|---------------------|
-| User account deletion (remove everything) | `Cascade` |
-| Prevent accidental deletion | `Restrict` |
-| Soft delete pattern | Don't delete; use status field |
-| Comments on posts | `Cascade` (comments meaningless without post) |
-| Products in orders | `Restrict` (orders are historical records) |
+| Scenario                                  | Recommended Behavior                          |
+| ----------------------------------------- | --------------------------------------------- |
+| User account deletion (remove everything) | `Cascade`                                     |
+| Prevent accidental deletion               | `Restrict`                                    |
+| Soft delete pattern                       | Don't delete; use status field                |
+| Comments on posts                         | `Cascade` (comments meaningless without post) |
+| Products in orders                        | `Restrict` (orders are historical records)    |
 
 ---
 

--- a/docs/guides/transactions.md
+++ b/docs/guides/transactions.md
@@ -218,9 +218,9 @@ match process_order(&database) {
 
 ### Transaction Errors
 
-| Error | Cause |
-|-------|-------|
-| `TransactionNotFound` | Invalid transaction ID or transaction already completed |
+| Error                 | Cause                                                       |
+| --------------------- | ----------------------------------------------------------- |
+| `TransactionNotFound` | Invalid transaction ID or transaction already completed     |
 | `NoActiveTransaction` | Attempting to commit/rollback without an active transaction |
 
 ```rust

--- a/docs/guides/wasmtime-example.md
+++ b/docs/guides/wasmtime-example.md
@@ -169,15 +169,15 @@ To add your own tables to the example:
 
 ## Key Concepts
 
-| Concept | Description |
-|---------|-------------|
-| **WIT** | WebAssembly Interface Types — a language for defining typed component interfaces |
-| **Component Model** | The standard for composing WASM modules with defined imports/exports |
-| **`wasm32-wasip2`** | Rust compilation target that produces WASM components with WASI Preview 2 support |
-| **`wit-bindgen`** | Guest-side code generator that creates Rust types from WIT definitions |
-| **`wasmtime::component::bindgen!`** | Host-side macro that generates Rust types for calling WIT interfaces |
-| **`DatabaseSchema`** | wasm-dbms trait that dispatches generic operations to concrete table types |
-| **`FileMemoryProvider`** | File-backed `MemoryProvider` implementation for persistent storage |
+| Concept                             | Description                                                                       |
+| ----------------------------------- | --------------------------------------------------------------------------------- |
+| **WIT**                             | WebAssembly Interface Types — a language for defining typed component interfaces  |
+| **Component Model**                 | The standard for composing WASM modules with defined imports/exports              |
+| **`wasm32-wasip2`**                 | Rust compilation target that produces WASM components with WASI Preview 2 support |
+| **`wit-bindgen`**                   | Guest-side code generator that creates Rust types from WIT definitions            |
+| **`wasmtime::component::bindgen!`** | Host-side macro that generates Rust types for calling WIT interfaces              |
+| **`DatabaseSchema`**                | wasm-dbms trait that dispatches generic operations to concrete table types        |
+| **`FileMemoryProvider`**            | File-backed `MemoryProvider` implementation for persistent storage                |
 
 ---
 

--- a/docs/ic/guides/client-api.md
+++ b/docs/ic/guides/client-api.md
@@ -45,7 +45,7 @@ constructing Candid calls, you use a high-level API that handles serialization a
 ic-dbms provides three client implementations for different use cases:
 
 | Client                 | Use Case                                       | Feature Flag |
-|------------------------|------------------------------------------------|--------------|
+| ---------------------- | ---------------------------------------------- | ------------ |
 | `IcDbmsCanisterClient` | Inter-canister calls (inside IC canisters)     | Default      |
 | `IcDbmsAgentClient`    | External applications (frontend, backend, CLI) | `ic-agent`   |
 | `IcDbmsPocketIcClient` | Integration tests with PocketIC                | `pocket-ic`  |

--- a/docs/ic/guides/crud-operations.md
+++ b/docs/ic/guides/crud-operations.md
@@ -31,11 +31,11 @@
 
 ic-dbms provides four fundamental database operations, accessed through the `ic-dbms-client` crate's `Client` trait. All operations use Candid serialization under the hood and support the IC's inter-canister call model.
 
-| Operation | Description | Returns |
-|-----------|-------------|---------|
-| **Insert** | Add a new record to a table | `Result<()>` |
-| **Select** | Query records from a table | `Result<Vec<Record>>` |
-| **Update** | Modify existing records | `Result<u64>` (affected rows) |
+| Operation  | Description                 | Returns                       |
+| ---------- | --------------------------- | ----------------------------- |
+| **Insert** | Add a new record to a table | `Result<()>`                  |
+| **Select** | Query records from a table  | `Result<Vec<Record>>`         |
+| **Update** | Modify existing records     | `Result<u64>` (affected rows) |
 | **Delete** | Remove records from a table | `Result<u64>` (affected rows) |
 
 All operations:
@@ -286,10 +286,10 @@ println!("Deleted {} record(s)", deleted);
 
 When deleting records that are referenced by foreign keys, you must specify a behavior:
 
-| Behavior | Description |
-|----------|-------------|
+| Behavior   | Description                                    |
+| ---------- | ---------------------------------------------- |
 | `Restrict` | Fail if any foreign keys reference this record |
-| `Cascade` | Delete all records that reference this record |
+| `Cascade`  | Delete all records that reference this record  |
 
 **Restrict Example:**
 
@@ -409,15 +409,15 @@ match client.insert::<User>(User::table_name(), user, None).await {
 
 Common error types:
 
-| Error | Cause | Operation |
-|-------|-------|-----------|
-| `PrimaryKeyConflict` | Record with same primary key exists | Insert |
+| Error                           | Cause                                                 | Operation              |
+| ------------------------------- | ----------------------------------------------------- | ---------------------- |
+| `PrimaryKeyConflict`            | Record with same primary key exists                   | Insert                 |
 | `ForeignKeyConstraintViolation` | Referenced record doesn't exist, or delete restricted | Insert, Update, Delete |
-| `BrokenForeignKeyReference` | Foreign key points to non-existent record | Insert, Update |
-| `UnknownColumn` | Invalid column name in filter or select | Select, Update, Delete |
-| `MissingNonNullableField` | Required field not provided | Insert, Update |
-| `RecordNotFound` | No record matches the criteria | Update, Delete |
-| `TransactionNotFound` | Invalid transaction ID | All |
-| `InvalidQuery` | Malformed query (e.g., invalid JSON path) | Select |
+| `BrokenForeignKeyReference`     | Foreign key points to non-existent record             | Insert, Update         |
+| `UnknownColumn`                 | Invalid column name in filter or select               | Select, Update, Delete |
+| `MissingNonNullableField`       | Required field not provided                           | Insert, Update         |
+| `RecordNotFound`                | No record matches the criteria                        | Update, Delete         |
+| `TransactionNotFound`           | Invalid transaction ID                                | All                    |
+| `InvalidQuery`                  | Malformed query (e.g., invalid JSON path)             | Select                 |
 
 See the [Errors Reference (IC)](../reference/errors.md) for complete IC-specific error documentation, or the [generic Errors Reference](../../reference/errors.md) for the full error hierarchy.

--- a/docs/ic/guides/get-started.md
+++ b/docs/ic/guides/get-started.md
@@ -145,7 +145,7 @@ pub struct Post {
 The `Table` macro generates additional types for each table:
 
 | Generated Type       | Purpose                                |
-|----------------------|----------------------------------------|
+| -------------------- | -------------------------------------- |
 | `UserRecord`         | Full record returned from queries      |
 | `UserInsertRequest`  | Request type for inserting records     |
 | `UserUpdateRequest`  | Request type for updating records      |

--- a/docs/ic/reference/data-types.md
+++ b/docs/ic/reference/data-types.md
@@ -115,26 +115,26 @@ pub struct Task {
 
 When ic-dbms generates the Candid interface (`.did` file) for your canister, each wasm-dbms type maps to a specific Candid type. This mapping is important for frontend integration, inter-canister calls, and using the Candid UI.
 
-| ic-dbms Type | Rust Type | Candid Type | Notes |
-|--------------|-----------|-------------|-------|
-| `Uint8` | `u8` | `nat8` | |
-| `Uint16` | `u16` | `nat16` | |
-| `Uint32` | `u32` | `nat32` | |
-| `Uint64` | `u64` | `nat64` | |
-| `Int8` | `i8` | `int8` | |
-| `Int16` | `i16` | `int16` | |
-| `Int32` | `i32` | `int32` | |
-| `Int64` | `i64` | `int64` | |
-| `Decimal` | `rust_decimal::Decimal` | `text` | Serialized as string for precision |
-| `Text` | `String` | `text` | |
-| `Boolean` | `bool` | `bool` | |
-| `Date` | `chrono::NaiveDate` | `record { year; month; day }` | Structured record |
-| `DateTime` | `chrono::DateTime<Utc>` | `int64` | Unix timestamp |
-| `Blob` | `Vec<u8>` | `blob` | |
-| `Principal` | `candid::Principal` | `principal` | IC-specific |
-| `Uuid` | `uuid::Uuid` | `text` | String representation |
-| `Json` | `serde_json::Value` | `text` | Serialized JSON string |
-| `Nullable<T>` | `Option<T>` | `opt T` | Candid optional |
+| ic-dbms Type  | Rust Type               | Candid Type                   | Notes                              |
+| ------------- | ----------------------- | ----------------------------- | ---------------------------------- |
+| `Uint8`       | `u8`                    | `nat8`                        |                                    |
+| `Uint16`      | `u16`                   | `nat16`                       |                                    |
+| `Uint32`      | `u32`                   | `nat32`                       |                                    |
+| `Uint64`      | `u64`                   | `nat64`                       |                                    |
+| `Int8`        | `i8`                    | `int8`                        |                                    |
+| `Int16`       | `i16`                   | `int16`                       |                                    |
+| `Int32`       | `i32`                   | `int32`                       |                                    |
+| `Int64`       | `i64`                   | `int64`                       |                                    |
+| `Decimal`     | `rust_decimal::Decimal` | `text`                        | Serialized as string for precision |
+| `Text`        | `String`                | `text`                        |                                    |
+| `Boolean`     | `bool`                  | `bool`                        |                                    |
+| `Date`        | `chrono::NaiveDate`     | `record { year; month; day }` | Structured record                  |
+| `DateTime`    | `chrono::DateTime<Utc>` | `int64`                       | Unix timestamp                     |
+| `Blob`        | `Vec<u8>`               | `blob`                        |                                    |
+| `Principal`   | `candid::Principal`     | `principal`                   | IC-specific                        |
+| `Uuid`        | `uuid::Uuid`            | `text`                        | String representation              |
+| `Json`        | `serde_json::Value`     | `text`                        | Serialized JSON string             |
+| `Nullable<T>` | `Option<T>`             | `opt T`                       | Candid optional                    |
 
 **Frontend integration example (JavaScript/TypeScript):**
 

--- a/docs/ic/reference/schema.md
+++ b/docs/ic/reference/schema.md
@@ -40,15 +40,15 @@ pub struct User {
 }
 ```
 
-| Derive / Attribute | Required for IC | Purpose |
-|--------------------|-----------------|---------|
-| `Table` | Yes | Generates table schema and related types |
-| `CandidType` | Yes (IC-specific) | Enables Candid serialization for the table struct |
-| `Deserialize` | Yes (IC-specific) | Enables deserialization from Candid wire format |
-| `#[candid]` | Yes (IC-specific) | Adds Candid/Serde derives to generated `Record`, `InsertRequest`, `UpdateRequest` types |
-| `Clone` | Yes | Required by the macro system |
-| `Debug` | Recommended | Useful for debugging |
-| `PartialEq`, `Eq` | Recommended | Useful for comparisons in tests |
+| Derive / Attribute | Required for IC   | Purpose                                                                                 |
+| ------------------ | ----------------- | --------------------------------------------------------------------------------------- |
+| `Table`            | Yes               | Generates table schema and related types                                                |
+| `CandidType`       | Yes (IC-specific) | Enables Candid serialization for the table struct                                       |
+| `Deserialize`      | Yes (IC-specific) | Enables deserialization from Candid wire format                                         |
+| `#[candid]`        | Yes (IC-specific) | Adds Candid/Serde derives to generated `Record`, `InsertRequest`, `UpdateRequest` types |
+| `Clone`            | Yes               | Required by the macro system                                                            |
+| `Debug`            | Recommended       | Useful for debugging                                                                    |
+| `PartialEq`, `Eq`  | Recommended       | Useful for comparisons in tests                                                         |
 
 Without `CandidType`, `Deserialize`, and `#[candid]`, the generated canister API will not compile because Candid is the serialization format used for all IC inter-canister calls.
 

--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -1,0 +1,170 @@
+# Query API Reference
+
+- [Query API Reference](#query-api-reference)
+  - [Overview](#overview)
+  - [Query Struct](#query-struct)
+  - [QueryBuilder](#querybuilder)
+    - [Field Selection](#field-selection)
+    - [Filters](#filters)
+    - [Joins](#joins)
+    - [Eager Loading](#eager-loading)
+    - [Distinct](#distinct)
+    - [Ordering](#ordering)
+    - [Pagination](#pagination)
+  - [Execution Order](#execution-order)
+  - [Related Types](#related-types)
+
+---
+
+## Overview
+
+A `Query` describes what to retrieve from the database: which rows match,
+which columns to return, how to order and paginate them, and how to combine
+data across tables. Queries are constructed with `QueryBuilder` and consumed
+by `Database::select`, `Database::select_raw`, and `Database::select_join`.
+
+For an introductory walkthrough, see the [Querying Guide](../guides/querying.md).
+
+---
+
+## Query Struct
+
+```rust
+pub struct Query {
+    columns: Select,
+    pub eager_relations: Vec<String>,
+    pub joins: Vec<Join>,
+    pub filter: Option<Filter>,
+    pub distinct_by: Vec<String>,
+    pub order_by: Vec<(String, OrderDirection)>,
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+}
+```
+
+| Field             | Type                            | Description                                       |
+|-------------------|---------------------------------|---------------------------------------------------|
+| `columns`         | `Select`                        | `Select::All` or `Select::Columns(Vec<String>)`   |
+| `eager_relations` | `Vec<String>`                   | Foreign-key relations to load eagerly             |
+| `joins`           | `Vec<Join>`                     | Join clauses (only valid via `select_join`)       |
+| `filter`          | `Option<Filter>`                | WHERE-clause expression                           |
+| `distinct_by`     | `Vec<String>`                   | Columns used to deduplicate results               |
+| `order_by`        | `Vec<(String, OrderDirection)>` | Multi-column ordering                             |
+| `limit`           | `Option<usize>`                 | Maximum number of records to return               |
+| `offset`          | `Option<usize>`                 | Number of records to skip                         |
+
+Use `Query::builder()` to obtain a `QueryBuilder`.
+
+---
+
+## QueryBuilder
+
+### Field Selection
+
+| Method          | Effect                                 |
+|-----------------|----------------------------------------|
+| `.all()`        | Selects all columns (`Select::All`)    |
+| `.field(name)`  | Adds a single column to the selection  |
+| `.fields(iter)` | Adds multiple columns                  |
+
+The primary key is always included by `Database::select::<T>` even when not explicitly listed.
+
+### Filters
+
+| Method                    | Effect                                     |
+|---------------------------|--------------------------------------------|
+| `.filter(Option<Filter>)` | Replaces the current filter                |
+| `.and_where(Filter)`      | Combines with existing filter using `AND`  |
+| `.or_where(Filter)`       | Combines with existing filter using `OR`   |
+
+See [Filters in the Querying Guide](../guides/querying.md#filters) and
+[JSON Filters](./json.md) for the full filter API.
+
+### Joins
+
+| Method                                    | Join type |
+|-------------------------------------------|-----------|
+| `.inner_join(table, left_col, right_col)` | INNER     |
+| `.left_join(table, left_col, right_col)`  | LEFT      |
+| `.right_join(table, left_col, right_col)` | RIGHT     |
+| `.full_join(table, left_col, right_col)`  | FULL      |
+
+Queries containing joins must be executed via `Database::select_join`. Calling
+`Database::select::<T>` with a joined query returns
+`QueryError::JoinInsideTypedSelect`.
+
+### Eager Loading
+
+```rust
+.with("posts")
+```
+
+Adds a foreign-key relation to load eagerly. Each relation is loaded once via a
+batch fetch keyed by the foreign-key column.
+
+### Distinct
+
+```rust
+.distinct(&["name"])
+.distinct(&["category", "vendor"])
+```
+
+Sets `distinct_by` to the supplied list of column names. Rows are deduplicated
+by the tuple of values across those columns; the first row encountered for each
+distinct tuple is retained. Passing an empty slice is a no-op.
+
+Semantics:
+
+- Columns are looked up on the source record (`ValuesSource::This`).
+- Missing columns are treated as `Value::Null`, so listing an unknown column
+  collapses every row into a single result.
+- Deduplication runs **before** ordering, offset, and limit.
+- The selected fields (`Select::Columns`) do not need to include the
+  `distinct_by` columns.
+
+### Ordering
+
+| Method                   | Effect                              |
+|--------------------------|-------------------------------------|
+| `.order_by_asc(column)`  | Appends ascending sort by `column`  |
+| `.order_by_desc(column)` | Appends descending sort by `column` |
+
+Multiple `order_by_*` calls produce stable multi-key sorts; later keys break
+ties from earlier keys.
+
+### Pagination
+
+| Method           | Effect                              |
+|------------------|-------------------------------------|
+| `.limit(usize)`  | Caps the number of records returned |
+| `.offset(usize)` | Skips the first N records           |
+
+---
+
+## Execution Order
+
+The select pipeline applies the query elements in this order — matching
+standard SQL semantics:
+
+1. **WHERE** — `filter` is applied while scanning records (or via an index plan).
+2. **DISTINCT** — `distinct_by` deduplicates the surviving rows.
+3. **Eager loading** — relations declared by `with(...)` are batch-fetched.
+4. **Column selection** — non-selected columns are dropped from each row.
+5. **ORDER BY** — `order_by` keys are applied in declared order.
+6. **OFFSET / LIMIT** — applied last when `order_by` or `distinct_by` is set;
+   otherwise applied during the scan for early termination.
+
+> When neither `order_by` nor `distinct_by` is present, the engine applies
+> `offset`/`limit` during iteration to avoid materialising the entire result
+> set.
+
+---
+
+## Related Types
+
+- [`Filter`](../guides/querying.md#filters) — predicates for `WHERE`
+- [`JsonFilter`](./json.md) — JSON-specific predicates
+- [`Join`, `JoinType`](../guides/querying.md#joins) — join clauses
+- [`OrderDirection`](../guides/querying.md#ordering) — ascending/descending
+- [`Select`](../guides/querying.md#field-selection) — `All` or `Columns(...)`
+- [`QueryError`](./errors.md) — query-time error variants

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -82,16 +82,16 @@ This design provides:
 
 **Key components:**
 
-| Component | Purpose |
-|-----------|---------|
-| `MemoryProvider` | Abstract interface for raw memory I/O |
-| `MemoryAccess` | Trait for page-level read/write operations (implemented by `MemoryManager`, interceptable by DBMS layer) |
-| `MemoryManager` | Allocates and manages pages, implements `MemoryAccess` |
-| `Encode` trait | Binary serialization for all stored types |
-| `PageLedger` | Tracks which pages belong to which table |
-| `FreeSegmentsLedger` | Tracks free space for reuse |
-| `IndexLedger` | Manages B+ tree indexes for a table |
-| `AutoincrementLedger` | Tracks autoincrement counters per column |
+| Component             | Purpose                                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------------------- |
+| `MemoryProvider`      | Abstract interface for raw memory I/O                                                                    |
+| `MemoryAccess`        | Trait for page-level read/write operations (implemented by `MemoryManager`, interceptable by DBMS layer) |
+| `MemoryManager`       | Allocates and manages pages, implements `MemoryAccess`                                                   |
+| `Encode` trait        | Binary serialization for all stored types                                                                |
+| `PageLedger`          | Tracks which pages belong to which table                                                                 |
+| `FreeSegmentsLedger`  | Tracks free space for reuse                                                                              |
+| `IndexLedger`         | Manages B+ tree indexes for a table                                                                      |
+| `AutoincrementLedger` | Tracks autoincrement counters per column                                                                 |
 
 **Memory layout:**
 
@@ -117,19 +117,19 @@ See [Memory Documentation](./memory.md) for detailed technical information.
 
 **Key components:**
 
-| Component | Purpose |
-|-----------|---------|
-| `DbmsContext<M>` | Owns all DBMS state (memory, schema, ACL, transactions, journal) |
-| `WasmDbmsDatabase` | Session-scoped DBMS operations |
-| `TableRegistry` | Manages records for a single table |
-| `TransactionSession` | Handles transaction lifecycle |
-| `Transaction` | Overlay for uncommitted changes |
-| `IndexOverlay` | Tracks uncommitted index changes within a transaction |
-| `Journal` | Write-ahead journal recording original bytes for rollback |
-| `JournaledWriter` | Wraps `MemoryManager` + `Journal`, implements `MemoryAccess` to intercept writes |
-| `FilterAnalyzer` | Extracts index plans from query filters |
-| `IndexReader` | Unified view over base index and transaction overlay |
-| `JoinEngine` | Executes cross-table join queries |
+| Component            | Purpose                                                                          |
+| -------------------- | -------------------------------------------------------------------------------- |
+| `DbmsContext<M>`     | Owns all DBMS state (memory, schema, ACL, transactions, journal)                 |
+| `WasmDbmsDatabase`   | Session-scoped DBMS operations                                                   |
+| `TableRegistry`      | Manages records for a single table                                               |
+| `TransactionSession` | Handles transaction lifecycle                                                    |
+| `Transaction`        | Overlay for uncommitted changes                                                  |
+| `IndexOverlay`       | Tracks uncommitted index changes within a transaction                            |
+| `Journal`            | Write-ahead journal recording original bytes for rollback                        |
+| `JournaledWriter`    | Wraps `MemoryManager` + `Journal`, implements `MemoryAccess` to intercept writes |
+| `FilterAnalyzer`     | Extracts index plans from query filters                                          |
+| `IndexReader`        | Unified view over base index and transaction overlay                             |
+| `JoinEngine`         | Executes cross-table join queries                                                |
 
 **Transaction model:**
 
@@ -174,12 +174,12 @@ Transactions use an overlay pattern:
 
 **Key components:**
 
-| Component | Purpose |
-|-----------|---------|
-| `DbmsCanister` macro | Generates canister API from schema |
-| ACL guard | Checks caller authorization |
-| Request types | `InsertRequest`, `UpdateRequest`, `Query` |
-| Response types | `Record`, error handling |
+| Component            | Purpose                                   |
+| -------------------- | ----------------------------------------- |
+| `DbmsCanister` macro | Generates canister API from schema        |
+| ACL guard            | Checks caller authorization               |
+| Request types        | `InsertRequest`, `UpdateRequest`, `Query` |
+| Response types       | `Record`, error handling                  |
 
 **Generated API structure:**
 

--- a/docs/technical/atomicity.md
+++ b/docs/technical/atomicity.md
@@ -93,11 +93,11 @@ struct JournalEntry {
 
 ### What is Journaled
 
-| Operation        | Journaled? | Why                                                              |
-|------------------|------------|------------------------------------------------------------------|
-| `write_at`       | Yes        | Modifies existing data that must be restorable                   |
-| `zero`           | Yes        | Modifies existing data (writes zeros)                            |
-| `allocate_page`  | No         | Newly allocated pages are unreferenced after rollback; their content is irrelevant |
+| Operation       | Journaled? | Why                                                                                |
+| --------------- | ---------- | ---------------------------------------------------------------------------------- |
+| `write_at`      | Yes        | Modifies existing data that must be restorable                                     |
+| `zero`          | Yes        | Modifies existing data (writes zeros)                                              |
+| `allocate_page` | No         | Newly allocated pages are unreferenced after rollback; their content is irrelevant |
 
 ---
 

--- a/docs/technical/join-engine.md
+++ b/docs/technical/join-engine.md
@@ -93,7 +93,7 @@ The `join()` method processes a query through these steps:
 All four join types are handled by a single `nested_loop_join` method using two boolean flags:
 
 | Join Type | `keep_unmatched_left` | `keep_unmatched_right` |
-|-----------|-----------------------|------------------------|
+| --------- | --------------------- | ---------------------- |
 | INNER     | `false`               | `false`                |
 | LEFT      | `true`                | `false`                |
 | RIGHT     | `false`               | `true`                 |

--- a/docs/technical/memory.md
+++ b/docs/technical/memory.md
@@ -129,11 +129,11 @@ pub trait MemoryProvider {
 
 **Implementations:**
 
-| Implementation | Use Case |
-|----------------|----------|
-| `IcMemoryProvider` | IC production (uses `ic_cdk::stable::*`) |
+| Implementation       | Use Case                                        |
+| -------------------- | ----------------------------------------------- |
+| `IcMemoryProvider`   | IC production (uses `ic_cdk::stable::*`)        |
 | `WasiMemoryProvider` | WASI production (file-backed, single flat file) |
-| `HeapMemoryProvider` | Testing (uses `Vec<u8>`) |
+| `HeapMemoryProvider` | Testing (uses `Vec<u8>`)                        |
 
 ```rust
 // Production: Uses IC stable memory APIs
@@ -259,13 +259,13 @@ pub enum DataSize {
 
 **Examples:**
 
-| Type | SIZE | ALIGNMENT |
-|------|------|-----------|
-| `Uint32` | `Fixed(4)` | 4 |
-| `Int64` | `Fixed(8)` | 8 |
-| `Text` | `Dynamic` | 32 (default) |
-| `Blob` | `Dynamic` | 32 (default) |
-| User-defined record | `Dynamic` | Configurable (default 32) |
+| Type                | SIZE       | ALIGNMENT                 |
+| ------------------- | ---------- | ------------------------- |
+| `Uint32`            | `Fixed(4)` | 4                         |
+| `Int64`             | `Fixed(8)` | 8                         |
+| `Text`              | `Dynamic`  | 32 (default)              |
+| `Blob`              | `Dynamic`  | 32 (default)              |
+| User-defined record | `Dynamic`  | Configurable (default 32) |
 
 ---
 
@@ -450,16 +450,16 @@ Offset   Size    Field
 
 **Supported types:**
 
-| Type | Range |
-|------|-------|
-| `Int8` | -128 to 127 |
-| `Int16` | -32,768 to 32,767 |
-| `Int32` | -2,147,483,648 to 2,147,483,647 |
-| `Int64` | -9.2 × 10¹⁸ to 9.2 × 10¹⁸ |
-| `Uint8` | 0 to 255 |
-| `Uint16` | 0 to 65,535 |
-| `Uint32` | 0 to 4,294,967,295 |
-| `Uint64` | 0 to 18.4 × 10¹⁸ |
+| Type     | Range                           |
+| -------- | ------------------------------- |
+| `Int8`   | -128 to 127                     |
+| `Int16`  | -32,768 to 32,767               |
+| `Int32`  | -2,147,483,648 to 2,147,483,647 |
+| `Int64`  | -9.2 × 10¹⁸ to 9.2 × 10¹⁸       |
+| `Uint8`  | 0 to 255                        |
+| `Uint16` | 0 to 65,535                     |
+| `Uint32` | 0 to 4,294,967,295              |
+| `Uint64` | 0 to 18.4 × 10¹⁸                |
 
 ---
 

--- a/docs/wasi/wasi-memory-provider.md
+++ b/docs/wasi/wasi-memory-provider.md
@@ -117,9 +117,9 @@ page layout, and vice versa. This enables workflows such as:
 All operations return `MemoryResult<T>` (an alias for `Result<T, MemoryError>`).
 The possible errors are:
 
-| Error | Cause |
-|-------|-------|
-| `MemoryError::OutOfBounds` | Read or write beyond allocated memory |
+| Error                                | Cause                                           |
+| ------------------------------------ | ----------------------------------------------- |
+| `MemoryError::OutOfBounds`           | Read or write beyond allocated memory           |
 | `MemoryError::ProviderError(String)` | File I/O failure, or file size not page-aligned |
 
 ---
@@ -135,10 +135,10 @@ across runtimes.
 
 ## Comparison with Other Providers
 
-| Provider | Use case | Backing storage |
-|----------|----------|-----------------|
+| Provider             | Use case        | Backing storage                |
+| -------------------- | --------------- | ------------------------------ |
 | `WasiMemoryProvider` | WASI production | Single flat file on filesystem |
-| `IcMemoryProvider` | IC production | IC stable memory APIs |
-| `HeapMemoryProvider` | Testing | In-process `Vec<u8>` |
+| `IcMemoryProvider`   | IC production   | IC stable memory APIs          |
+| `HeapMemoryProvider` | Testing         | In-process `Vec<u8>`           |
 
 All three share the same page layout, so data is portable across implementations.


### PR DESCRIPTION
## Summary

- Adds `distinct_by: Vec<String>` to `Query` and `.distinct(&[..])` builder method.
- `select_columns` pipeline deduplicates by listed columns before `ORDER BY` / `OFFSET` / `LIMIT`, matching SQL semantics (`WHERE` -> `DISTINCT` -> eager -> column selection -> `ORDER BY` -> `OFFSET`/`LIMIT`).
- Missing columns hash as `Value::Null`; first row per distinct tuple is kept.
- New `docs/reference/query.md` and DISTINCT section in `docs/guides/querying.md`.

Closes #85.

## Test plan

- [x] `cargo test -p wasm-dbms --lib` (192 passed; 10 new distinct tests)
- [x] `cargo build -p wasm-dbms`
- [ ] CI green