### PR TITLE
feat(migrations): snapshot-driven record codec for column-mutating ops

### DIFF
--- a/crates/ic-dbms/ic-dbms-api/src/tests.rs
+++ b/crates/ic-dbms/ic-dbms-api/src/tests.rs
@@ -320,7 +320,9 @@ mod custom_type_tests {
     use std::fmt;
 
     use crate::dbms::custom_value::CustomValue;
-    use crate::dbms::table::{ColumnDef, TableColumns, TableRecord, TableSchema, ValuesSource};
+    use crate::dbms::table::{
+        ColumnDef, TableColumns, TableRecord, TableSchema, ValuesSource, WireSize,
+    };
     use crate::dbms::types::{CustomDataType, DataTypeKind, Nullable, Text, Uint32};
     use crate::dbms::value::Value;
     use crate::memory::{DEFAULT_ALIGNMENT, DataSize, Encode, MSize, MemoryResult, PageOffset};
@@ -424,7 +426,13 @@ mod custom_type_tests {
         assert_eq!(columns[0].name, "id");
         assert_eq!(columns[0].data_type, DataTypeKind::Uint32);
         assert_eq!(columns[1].name, "priority");
-        assert_eq!(columns[1].data_type, DataTypeKind::Custom("priority"));
+        assert_eq!(
+            columns[1].data_type,
+            DataTypeKind::Custom {
+                tag: "priority",
+                wire_size: WireSize::Fixed(1),
+            }
+        );
     }
 
     #[test]

--- a/crates/wasm-dbms/example/guest/src/lib.rs
+++ b/crates/wasm-dbms/example/guest/src/lib.rs
@@ -379,7 +379,17 @@ fn data_type_to_wit(t: DataTypeSnapshot) -> wit::DataTypeSnapshot {
         DataTypeSnapshot::Text => wit::DataTypeSnapshot::Text,
         DataTypeSnapshot::Uuid => wit::DataTypeSnapshot::Uuid,
         DataTypeSnapshot::Json => wit::DataTypeSnapshot::Json,
-        DataTypeSnapshot::Custom(name) => wit::DataTypeSnapshot::Custom(name),
+        DataTypeSnapshot::Custom(meta) => {
+            wit::DataTypeSnapshot::Custom(wit::CustomDataTypeSnapshot {
+                tag: meta.tag.clone(),
+                wire_size: match meta.wire_size {
+                    wasm_dbms_api::prelude::WireSize::Fixed(n) => wit::WireSize::Fixed(n),
+                    wasm_dbms_api::prelude::WireSize::LengthPrefixed => {
+                        wit::WireSize::LengthPrefixed
+                    }
+                },
+            })
+        }
     }
 }
 

--- a/crates/wasm-dbms/example/guest/src/lib.rs
+++ b/crates/wasm-dbms/example/guest/src/lib.rs
@@ -357,6 +357,158 @@ fn intern_str(s: &str) -> &'static str {
     })
 }
 
+// ── Migration conversion ────────────────────────────────────────────
+
+fn data_type_to_wit(t: DataTypeSnapshot) -> wit::DataTypeSnapshot {
+    match t {
+        DataTypeSnapshot::Int8 => wit::DataTypeSnapshot::Int8,
+        DataTypeSnapshot::Int16 => wit::DataTypeSnapshot::Int16,
+        DataTypeSnapshot::Int32 => wit::DataTypeSnapshot::Int32,
+        DataTypeSnapshot::Int64 => wit::DataTypeSnapshot::Int64,
+        DataTypeSnapshot::Uint8 => wit::DataTypeSnapshot::Uint8,
+        DataTypeSnapshot::Uint16 => wit::DataTypeSnapshot::Uint16,
+        DataTypeSnapshot::Uint32 => wit::DataTypeSnapshot::Uint32,
+        DataTypeSnapshot::Uint64 => wit::DataTypeSnapshot::Uint64,
+        DataTypeSnapshot::Float32 => wit::DataTypeSnapshot::Float32,
+        DataTypeSnapshot::Float64 => wit::DataTypeSnapshot::Float64,
+        DataTypeSnapshot::Decimal => wit::DataTypeSnapshot::Decimal,
+        DataTypeSnapshot::Boolean => wit::DataTypeSnapshot::Boolean,
+        DataTypeSnapshot::Date => wit::DataTypeSnapshot::Date,
+        DataTypeSnapshot::Datetime => wit::DataTypeSnapshot::Datetime,
+        DataTypeSnapshot::Blob => wit::DataTypeSnapshot::Blob,
+        DataTypeSnapshot::Text => wit::DataTypeSnapshot::Text,
+        DataTypeSnapshot::Uuid => wit::DataTypeSnapshot::Uuid,
+        DataTypeSnapshot::Json => wit::DataTypeSnapshot::Json,
+        DataTypeSnapshot::Custom(name) => wit::DataTypeSnapshot::Custom(name),
+    }
+}
+
+fn on_delete_to_wit(d: OnDeleteSnapshot) -> wit::OnDeleteSnapshot {
+    match d {
+        OnDeleteSnapshot::Restrict => wit::OnDeleteSnapshot::Restrict,
+        OnDeleteSnapshot::Cascade => wit::OnDeleteSnapshot::Cascade,
+    }
+}
+
+fn fk_snapshot_to_wit(fk: ForeignKeySnapshot) -> wit::ForeignKeySnapshot {
+    wit::ForeignKeySnapshot {
+        table: fk.table,
+        column: fk.column,
+        on_delete: on_delete_to_wit(fk.on_delete),
+    }
+}
+
+fn column_snapshot_to_wit(c: ColumnSnapshot) -> wit::ColumnSnapshot {
+    wit::ColumnSnapshot {
+        name: c.name,
+        data_type: data_type_to_wit(c.data_type),
+        nullable: c.nullable,
+        auto_increment: c.auto_increment,
+        unique: c.unique,
+        primary_key: c.primary_key,
+        foreign_key: c.foreign_key.map(fk_snapshot_to_wit),
+        default: c.default.map(dbms_value_to_wit),
+    }
+}
+
+fn index_snapshot_to_wit(i: IndexSnapshot) -> wit::IndexSnapshot {
+    wit::IndexSnapshot {
+        columns: i.columns,
+        unique: i.unique,
+    }
+}
+
+fn table_snapshot_to_wit(s: TableSchemaSnapshot) -> wit::TableSchemaSnapshot {
+    wit::TableSchemaSnapshot {
+        version: s.version,
+        name: s.name,
+        primary_key: s.primary_key,
+        alignment: s.alignment,
+        columns: s.columns.into_iter().map(column_snapshot_to_wit).collect(),
+        indexes: s.indexes.into_iter().map(index_snapshot_to_wit).collect(),
+    }
+}
+
+fn column_changes_to_wit(c: ColumnChanges) -> wit::ColumnChanges {
+    wit::ColumnChanges {
+        nullable: c.nullable,
+        unique: c.unique,
+        auto_increment: c.auto_increment,
+        primary_key: c.primary_key,
+        foreign_key: c.foreign_key.map(|fk| match fk {
+            None => wit::ForeignKeyChange::Drop,
+            Some(fk) => wit::ForeignKeyChange::Set(fk_snapshot_to_wit(fk)),
+        }),
+    }
+}
+
+fn migration_op_to_wit(op: MigrationOp) -> wit::MigrationOp {
+    match op {
+        MigrationOp::CreateTable { name, schema } => {
+            wit::MigrationOp::CreateTable(wit::CreateTableOp {
+                name,
+                schema: table_snapshot_to_wit(schema),
+            })
+        }
+        MigrationOp::DropTable { name } => wit::MigrationOp::DropTable(name),
+        MigrationOp::AddColumn { table, column } => wit::MigrationOp::AddColumn(wit::AddColumnOp {
+            table,
+            column: column_snapshot_to_wit(column),
+        }),
+        MigrationOp::DropColumn { table, column } => {
+            wit::MigrationOp::DropColumn(wit::DropColumnOp { table, column })
+        }
+        MigrationOp::RenameColumn { table, old, new } => {
+            wit::MigrationOp::RenameColumn(wit::RenameColumnOp { table, old, new })
+        }
+        MigrationOp::AlterColumn {
+            table,
+            column,
+            changes,
+        } => wit::MigrationOp::AlterColumn(wit::AlterColumnOp {
+            table,
+            column,
+            changes: column_changes_to_wit(changes),
+        }),
+        MigrationOp::WidenColumn {
+            table,
+            column,
+            old_type,
+            new_type,
+        } => wit::MigrationOp::WidenColumn(wit::TypeChangeOp {
+            table,
+            column,
+            old_type: data_type_to_wit(old_type),
+            new_type: data_type_to_wit(new_type),
+        }),
+        MigrationOp::TransformColumn {
+            table,
+            column,
+            old_type,
+            new_type,
+        } => wit::MigrationOp::TransformColumn(wit::TypeChangeOp {
+            table,
+            column,
+            old_type: data_type_to_wit(old_type),
+            new_type: data_type_to_wit(new_type),
+        }),
+        MigrationOp::AddIndex { table, index } => wit::MigrationOp::AddIndex(wit::IndexOp {
+            table,
+            index: index_snapshot_to_wit(index),
+        }),
+        MigrationOp::DropIndex { table, index } => wit::MigrationOp::DropIndex(wit::IndexOp {
+            table,
+            index: index_snapshot_to_wit(index),
+        }),
+    }
+}
+
+fn wit_migration_policy(p: wit::MigrationPolicy) -> MigrationPolicy {
+    MigrationPolicy {
+        allow_destructive: p.allow_destructive,
+    }
+}
+
 // ── Guest implementation ────────────────────────────────────────────
 
 struct GuestDbms;
@@ -482,6 +634,30 @@ impl exports::wasm_dbms::dbms::database::Guest for GuestDbms {
         with_dbms(|ctx| {
             let mut db = WasmDbmsDatabase::from_transaction(ctx, ExampleDatabaseSchema, tx);
             db.rollback().map_err(dbms_error_to_wit)
+        })
+    }
+
+    fn has_drift() -> Result<bool, wit::DbmsError> {
+        with_dbms(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, ExampleDatabaseSchema);
+            db.has_drift().map_err(dbms_error_to_wit)
+        })
+    }
+
+    fn pending_migrations() -> Result<Vec<wit::MigrationOp>, wit::DbmsError> {
+        with_dbms(|ctx| {
+            let db = WasmDbmsDatabase::oneshot(ctx, ExampleDatabaseSchema);
+            db.pending_migrations()
+                .map(|ops| ops.into_iter().map(migration_op_to_wit).collect())
+                .map_err(dbms_error_to_wit)
+        })
+    }
+
+    fn migrate(policy: wit::MigrationPolicy) -> Result<(), wit::DbmsError> {
+        let policy = wit_migration_policy(policy);
+        with_dbms(|ctx| {
+            let mut db = WasmDbmsDatabase::oneshot(ctx, ExampleDatabaseSchema);
+            db.migrate(policy).map_err(dbms_error_to_wit)
         })
     }
 }

--- a/crates/wasm-dbms/example/host/src/main.rs
+++ b/crates/wasm-dbms/example/host/src/main.rs
@@ -24,7 +24,7 @@ wasmtime::component::bindgen!({
 });
 
 use crate::wasm_dbms::dbms::types::{
-    ColumnValue, DbmsError, OrderDirection, OrderKey, Query, Value,
+    ColumnValue, DbmsError, MigrationPolicy, OrderDirection, OrderKey, Query, Value,
 };
 
 /// Default path to the pre-built guest component.
@@ -285,6 +285,19 @@ fn main() -> Result<()> {
         .map_err(dbms_err)?;
     assert!(rows.is_empty(), "Eve should NOT exist after rollback");
     println!("  Verified: Eve does NOT exist after rollback.");
+    println!();
+
+    // ── Schema migrations ───────────────────────────────────────────
+    println!("--- Schema migrations smoke test ---");
+    let drift = db.call_has_drift(&mut store)?.map_err(dbms_err)?;
+    println!("  has_drift = {drift}");
+    let ops = db.call_pending_migrations(&mut store)?.map_err(dbms_err)?;
+    println!("  pending_migrations.len() = {}", ops.len());
+    let policy = MigrationPolicy {
+        allow_destructive: false,
+    };
+    db.call_migrate(&mut store, policy)?.map_err(dbms_err)?;
+    println!("  migrate() applied (no-op)");
     println!();
 
     // ── Final state ─────────────────────────────────────────────────

--- a/crates/wasm-dbms/wasm-dbms-api/src/dbms/database.rs
+++ b/crates/wasm-dbms/wasm-dbms-api/src/dbms/database.rs
@@ -357,8 +357,11 @@ pub trait Database {
     ///
     /// - [`MigrationError::DestructiveOpDenied`](crate::prelude::MigrationError::DestructiveOpDenied)
     ///   when the planner emits a destructive op disallowed by `policy`.
-    /// - [`MigrationError::DataRewriteUnsupported`](crate::prelude::MigrationError::DataRewriteUnsupported)
-    ///   for column-mutating ops not yet implemented (see issue #91).
+    /// - [`MigrationError::DefaultMissing`](crate::prelude::MigrationError::DefaultMissing)
+    ///   when an `AddColumn` op cannot resolve a default for a non-nullable
+    ///   column.
+    /// - [`MigrationError::WideningIncompatible`](crate::prelude::MigrationError::WideningIncompatible)
+    ///   when a `WidenColumn` op falls outside the widening whitelist.
     /// - Any other [`MigrationError`](crate::prelude::MigrationError) variant
     ///   raised by the diff or apply pipeline.
     fn migrate(&mut self, policy: MigrationPolicy) -> DbmsResult<()>;

--- a/crates/wasm-dbms/wasm-dbms-api/src/dbms/migration.rs
+++ b/crates/wasm-dbms/wasm-dbms-api/src/dbms/migration.rs
@@ -38,7 +38,7 @@ where
     ///
     /// Returning `None` falls back to the static `#[default = ...]` attribute
     /// declared on the column. If neither produces a value, migration aborts
-    /// with [`MigrationError::MissingDefault`].
+    /// with [`MigrationError::DefaultMissing`].
     fn default_value(_column: &str) -> Option<Value> {
         None
     }
@@ -217,7 +217,7 @@ pub enum MigrationError {
     /// `AddColumn` on a non-nullable column has neither a `#[default]`
     /// attribute nor a [`Migrate::default_value`] override.
     #[error("Missing default for non-nullable new column `{column}` in table `{table}`")]
-    MissingDefault {
+    DefaultMissing {
         /// Table the column belongs to.
         table: String,
         /// Name of the offending column.
@@ -251,14 +251,45 @@ pub enum MigrationError {
         /// Reason propagated from the user transform.
         reason: String,
     },
-    /// Column-mutating op (`AddColumn`, `DropColumn`, `RenameColumn`,
-    /// `WidenColumn`, `TransformColumn`) requires a snapshot-driven record
-    /// (de)serializer that is tracked separately and not yet wired into the
-    /// apply pipeline.
-    #[error("Migration op `{op}` requires snapshot-driven record rewrite (see issue #91)")]
-    DataRewriteUnsupported {
-        /// Short tag for the offending op kind.
-        op: String,
+    /// Type change is outside the widening whitelist
+    /// (`IntN→IntM`, `UintN→UintM`, `UintN→IntM`, `Float32→Float64`) and no
+    /// `Migrate::transform_column` impl handled it.
+    #[error(
+        "No widening rule for column `{column}` in table `{table}`: {old_type:?} -> {new_type:?}"
+    )]
+    WideningIncompatible {
+        /// Table the column belongs to.
+        table: String,
+        /// Name of the offending column.
+        column: String,
+        /// Stored data type before widening.
+        old_type: DataTypeSnapshot,
+        /// Compiled data type after widening.
+        new_type: DataTypeSnapshot,
+    },
+    /// User `Migrate::transform_column` returned `Ok(None)` while a transform
+    /// was required (no widening rule available).
+    #[error("Migrate::transform_column returned None for column `{column}` in table `{table}`")]
+    TransformReturnedNone {
+        /// Table the column belongs to.
+        table: String,
+        /// Name of the column being transformed.
+        column: String,
+    },
+    /// Add-FK tightening found a row whose value is absent from the target
+    /// table's referenced column.
+    #[error(
+        "Foreign key violation on column `{column}` in table `{table}`: value `{value}` not present in `{target_table}`"
+    )]
+    ForeignKeyViolation {
+        /// Source table that holds the foreign key column.
+        table: String,
+        /// Source column carrying the foreign key.
+        column: String,
+        /// Target table the FK references.
+        target_table: String,
+        /// Stringified value that failed the lookup.
+        value: String,
     },
 }
 
@@ -301,7 +332,7 @@ mod test {
         };
         assert!(err.to_string().contains("Incompatible type change"));
 
-        let err = MigrationError::MissingDefault {
+        let err = MigrationError::DefaultMissing {
             table: "users".into(),
             column: "email".into(),
         };
@@ -363,5 +394,37 @@ mod test {
         let encoded = candid::encode_one(&err).expect("failed to encode");
         let decoded: MigrationError = candid::decode_one(&encoded).expect("failed to decode");
         assert_eq!(err, decoded);
+    }
+
+    #[cfg(feature = "candid")]
+    #[test]
+    fn test_should_candid_roundtrip_new_migration_error_variants() {
+        let cases = vec![
+            MigrationError::DefaultMissing {
+                table: "users".into(),
+                column: "email".into(),
+            },
+            MigrationError::WideningIncompatible {
+                table: "users".into(),
+                column: "id".into(),
+                old_type: DataTypeSnapshot::Int32,
+                new_type: DataTypeSnapshot::Uint8,
+            },
+            MigrationError::TransformReturnedNone {
+                table: "users".into(),
+                column: "id".into(),
+            },
+            MigrationError::ForeignKeyViolation {
+                table: "posts".into(),
+                column: "owner".into(),
+                target_table: "users".into(),
+                value: "Uint32(99)".into(),
+            },
+        ];
+        for err in cases {
+            let encoded = candid::encode_one(&err).expect("failed to encode");
+            let decoded: MigrationError = candid::decode_one(&encoded).expect("failed to decode");
+            assert_eq!(err, decoded);
+        }
     }
 }

--- a/crates/wasm-dbms/wasm-dbms-api/src/dbms/table.rs
+++ b/crates/wasm-dbms/wasm-dbms-api/src/dbms/table.rs
@@ -14,8 +14,9 @@ pub use self::record::{
     InsertRecord, TableColumns, TableRecord, UpdateRecord, ValuesSource, flatten_table_columns,
 };
 pub use self::schema::{
-    ColumnSnapshot, DataTypeSnapshot, ForeignKeySnapshot, IndexSnapshot, OnDeleteSnapshot,
-    TableFingerprint, TableSchema, TableSchemaSnapshot, fingerprint_for_name,
+    ColumnSnapshot, CustomDataTypeSnapshot, DataTypeSnapshot, ForeignKeySnapshot, IndexSnapshot,
+    OnDeleteSnapshot, TableFingerprint, TableSchema, TableSchemaSnapshot, WireSize,
+    fingerprint_for_name,
 };
 
 /// Table related errors

--- a/crates/wasm-dbms/wasm-dbms-api/src/dbms/table/column_def.rs
+++ b/crates/wasm-dbms/wasm-dbms-api/src/dbms/table/column_def.rs
@@ -33,7 +33,7 @@ pub struct ColumnDef {
     /// Populated by the `#[default = ...]` attribute on a `#[derive(Table)]`
     /// field. Consumed by the migration planner when adding a non-nullable
     /// column to satisfy the
-    /// [`MissingDefault`](crate::dbms::migration::MigrationError::MissingDefault)
+    /// [`DefaultMissing`](crate::dbms::migration::MigrationError::DefaultMissing)
     /// check.
     pub default: Option<DefaultValueFn>,
     /// Previous names this column was known by, in chronological order.
@@ -129,7 +129,7 @@ impl From<DataTypeKind> for CandidDataTypeKind {
             DataTypeKind::Uint32 => Self::Uint32,
             DataTypeKind::Uint64 => Self::Uint64,
             DataTypeKind::Uuid => Self::Uuid,
-            DataTypeKind::Custom(s) => Self::Custom(s.to_string()),
+            DataTypeKind::Custom { tag, .. } => Self::Custom(tag.to_string()),
         }
     }
 }
@@ -394,7 +394,11 @@ mod test {
 
     #[test]
     fn test_should_convert_custom_data_type_kind_to_candid() {
-        let kind = DataTypeKind::Custom("role");
+        use crate::dbms::table::WireSize;
+        let kind = DataTypeKind::Custom {
+            tag: "role",
+            wire_size: WireSize::Fixed(1),
+        };
         let candid_kind = CandidDataTypeKind::from(kind);
         assert_eq!(candid_kind, CandidDataTypeKind::Custom("role".to_string()));
     }
@@ -408,9 +412,13 @@ mod test {
 
     #[test]
     fn test_should_create_candid_column_def_with_custom_type() {
+        use crate::dbms::table::WireSize;
         let col = ColumnDef {
             name: "role",
-            data_type: DataTypeKind::Custom("role"),
+            data_type: DataTypeKind::Custom {
+                tag: "role",
+                wire_size: WireSize::Fixed(1),
+            },
             auto_increment: false,
             nullable: false,
             primary_key: false,

--- a/crates/wasm-dbms/wasm-dbms-api/src/dbms/table/schema.rs
+++ b/crates/wasm-dbms/wasm-dbms-api/src/dbms/table/schema.rs
@@ -3,8 +3,8 @@ pub mod snapshot;
 use xxhash_rust::xxh3::xxh3_64;
 
 pub use self::snapshot::{
-    ColumnSnapshot, DataTypeSnapshot, ForeignKeySnapshot, IndexSnapshot, OnDeleteSnapshot,
-    TableSchemaSnapshot,
+    ColumnSnapshot, CustomDataTypeSnapshot, DataTypeSnapshot, ForeignKeySnapshot, IndexSnapshot,
+    OnDeleteSnapshot, TableSchemaSnapshot, WireSize,
 };
 use crate::dbms::foreign_fetcher::ForeignFetcher;
 use crate::dbms::table::column_def::{ColumnDef, IndexDef};
@@ -35,7 +35,12 @@ fn data_type_to_snapshot(kind: &DataTypeKind) -> DataTypeSnapshot {
         DataTypeKind::Uint32 => DataTypeSnapshot::Uint32,
         DataTypeKind::Uint64 => DataTypeSnapshot::Uint64,
         DataTypeKind::Uuid => DataTypeSnapshot::Uuid,
-        DataTypeKind::Custom(tag) => DataTypeSnapshot::Custom((*tag).to_string()),
+        DataTypeKind::Custom { tag, wire_size } => {
+            DataTypeSnapshot::Custom(Box::new(CustomDataTypeSnapshot {
+                tag: (*tag).to_string(),
+                wire_size: *wire_size,
+            }))
+        }
     }
 }
 

--- a/crates/wasm-dbms/wasm-dbms-api/src/dbms/table/schema/snapshot.rs
+++ b/crates/wasm-dbms/wasm-dbms-api/src/dbms/table/schema/snapshot.rs
@@ -58,6 +58,50 @@ pub struct ColumnSnapshot {
     pub default: Option<Value>,
 }
 
+/// On-disk wire layout descriptor for a custom-typed column.
+///
+/// Tells the snapshot-driven record codec how many bytes a custom column
+/// occupies in a stored record, without needing access to the user's
+/// concrete `Encode` impl. Derived from `<T as Encode>::SIZE` at the time
+/// the snapshot is built.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "candid", derive(candid::CandidType))]
+pub enum WireSize {
+    /// Column occupies exactly N bytes per record (`Encode::SIZE = Fixed(N)`).
+    Fixed(u32),
+    /// Column body is preceded by a 2-byte little-endian length prefix
+    /// (the convention used by `Text`, `Blob`, `Json`, and any custom
+    /// dynamic-size type — `Encode::SIZE = Dynamic`).
+    LengthPrefixed,
+}
+
+/// User-defined custom-type metadata carried inside
+/// [`DataTypeSnapshot::Custom`]. Boxed in the parent enum so the discriminant
+/// stays compact (the migration error variants embed two `DataTypeSnapshot`s
+/// each, and an inline `String` + `WireSize` would bloat
+/// [`crate::error::DbmsError`] past clippy's `result_large_err` threshold).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "candid", derive(candid::CandidType))]
+pub struct CustomDataTypeSnapshot {
+    /// Stable type identifier (`CustomDataType::TYPE_TAG`).
+    pub tag: String,
+    /// On-disk wire layout used by the snapshot codec.
+    pub wire_size: WireSize,
+}
+
+impl WireSize {
+    /// Derive the on-disk wire layout from a custom type's [`DataSize`].
+    ///
+    /// `const fn` so generated code can use it inside `&[ColumnDef]`
+    /// promotable array literals.
+    pub const fn from_data_size(size: DataSize) -> Self {
+        match size {
+            DataSize::Fixed(n) => Self::Fixed(n as u32),
+            DataSize::Dynamic => Self::LengthPrefixed,
+        }
+    }
+}
+
 /// Stable, tag-keyed encoding of a column data type.
 ///
 /// The discriminants are part of the on-disk format and must not be reused or reordered; new variants must take a fresh tag.
@@ -69,8 +113,8 @@ pub enum DataTypeSnapshot {
     Blob = 0x50,
     /// Boolean value.
     Boolean = 0x30,
-    /// User-defined custom data type, identified by name.
-    Custom(String) = 0xF0, // name-keyed
+    /// User-defined custom data type, identified by name + on-disk wire layout.
+    Custom(Box<CustomDataTypeSnapshot>) = 0xF0,
     /// Calendar date with no time component.
     Date = 0x40,
     /// Date and time.
@@ -283,8 +327,16 @@ impl Encode for DataTypeSnapshot {
 
     fn size(&self) -> crate::prelude::MSize {
         match self {
-            // 1 tag + 1 name_len + name bytes
-            DataTypeSnapshot::Custom(name) => 1 + 1 + name.len() as crate::prelude::MSize,
+            // 1 tag + wire_size header + 1 name_len + name bytes
+            DataTypeSnapshot::Custom(meta) => {
+                let ws_bytes: crate::prelude::MSize = match meta.wire_size {
+                    // 1 ws_tag + 4 (u32 LE)
+                    WireSize::Fixed(_) => 1 + 4,
+                    // 1 ws_tag
+                    WireSize::LengthPrefixed => 1,
+                };
+                1 + ws_bytes + 1 + meta.tag.len() as crate::prelude::MSize
+            }
             // single tag byte
             _ => 1,
         }
@@ -314,11 +366,20 @@ impl Encode for DataTypeSnapshot {
         };
 
         match self {
-            DataTypeSnapshot::Custom(name) => {
-                let mut bytes = Vec::with_capacity(2 + name.len());
+            DataTypeSnapshot::Custom(meta) => {
+                let mut bytes = Vec::with_capacity(self.size() as usize);
                 bytes.push(tag);
-                bytes.push(name.len() as u8);
-                bytes.extend_from_slice(name.as_bytes());
+                match meta.wire_size {
+                    WireSize::Fixed(n) => {
+                        bytes.push(0x01u8);
+                        bytes.extend_from_slice(&n.to_le_bytes());
+                    }
+                    WireSize::LengthPrefixed => {
+                        bytes.push(0x02u8);
+                    }
+                }
+                bytes.push(meta.tag.len() as u8);
+                bytes.extend_from_slice(meta.tag.as_bytes());
                 std::borrow::Cow::Owned(bytes)
             }
             _ => std::borrow::Cow::Owned(vec![tag]),
@@ -357,12 +418,34 @@ impl Encode for DataTypeSnapshot {
                 if data.len() < 2 {
                     return Err(MemoryError::DecodeError(DecodeError::TooShort));
                 }
-                let name_len = data[1] as usize;
-                if data.len() < 2 + name_len {
+                let (wire_size, header_len) = match data[1] {
+                    0x01 => {
+                        if data.len() < 6 {
+                            return Err(MemoryError::DecodeError(DecodeError::TooShort));
+                        }
+                        let n = u32::from_le_bytes([data[2], data[3], data[4], data[5]]);
+                        (WireSize::Fixed(n), 6)
+                    }
+                    0x02 => (WireSize::LengthPrefixed, 2),
+                    v => {
+                        return Err(MemoryError::DecodeError(DecodeError::IdentityDecodeError(
+                            format!("Unknown WireSize tag: {v:#x}"),
+                        )));
+                    }
+                };
+                if data.len() < header_len + 1 {
                     return Err(MemoryError::DecodeError(DecodeError::TooShort));
                 }
-                let name = String::from_utf8(data[2..2 + name_len].to_vec())?;
-                Ok(DataTypeSnapshot::Custom(name))
+                let name_len = data[header_len] as usize;
+                let name_off = header_len + 1;
+                if data.len() < name_off + name_len {
+                    return Err(MemoryError::DecodeError(DecodeError::TooShort));
+                }
+                let tag = String::from_utf8(data[name_off..name_off + name_len].to_vec())?;
+                Ok(DataTypeSnapshot::Custom(Box::new(CustomDataTypeSnapshot {
+                    tag,
+                    wire_size,
+                })))
             }
             value => Err(MemoryError::DecodeError(DecodeError::IdentityDecodeError(
                 format!("Unknown `DataTypeSnapshot` tag: {value:#x}"),
@@ -470,7 +553,19 @@ impl Encode for ColumnSnapshot {
             if data.len() < offset + 2 {
                 return Err(MemoryError::DecodeError(DecodeError::TooShort));
             }
-            2 + data[offset + 1] as usize
+            let header = match data[offset + 1] {
+                0x01 => 6,
+                0x02 => 2,
+                v => {
+                    return Err(MemoryError::DecodeError(DecodeError::IdentityDecodeError(
+                        format!("Unknown WireSize tag: {v:#x}"),
+                    )));
+                }
+            };
+            if data.len() < offset + header + 1 {
+                return Err(MemoryError::DecodeError(DecodeError::TooShort));
+            }
+            header + 1 + data[offset + header] as usize
         } else {
             1
         };
@@ -798,12 +893,36 @@ mod tests {
             DataTypeSnapshot::Uint32,
             DataTypeSnapshot::Uint64,
             DataTypeSnapshot::Uuid,
-            DataTypeSnapshot::Custom("Money".to_string()),
-            DataTypeSnapshot::Custom(String::new()),
+            DataTypeSnapshot::Custom(Box::new(CustomDataTypeSnapshot {
+                tag: "Money".to_string(),
+                wire_size: WireSize::Fixed(16),
+            })),
+            DataTypeSnapshot::Custom(Box::new(CustomDataTypeSnapshot {
+                tag: String::new(),
+                wire_size: WireSize::LengthPrefixed,
+            })),
         ];
         for dt in cases {
             assert_eq!(roundtrip(dt.clone()), dt);
         }
+    }
+
+    #[test]
+    fn test_custom_wire_size_fixed_roundtrip() {
+        let dt = DataTypeSnapshot::Custom(Box::new(CustomDataTypeSnapshot {
+            tag: "Money".to_string(),
+            wire_size: WireSize::Fixed(8),
+        }));
+        assert_eq!(roundtrip(dt.clone()), dt);
+    }
+
+    #[test]
+    fn test_custom_wire_size_length_prefixed_roundtrip() {
+        let dt = DataTypeSnapshot::Custom(Box::new(CustomDataTypeSnapshot {
+            tag: "Json".to_string(),
+            wire_size: WireSize::LengthPrefixed,
+        }));
+        assert_eq!(roundtrip(dt.clone()), dt);
     }
 
     #[test]
@@ -845,7 +964,14 @@ mod tests {
         assert_eq!(DataTypeSnapshot::Text.encode()[0], 0x51);
         assert_eq!(DataTypeSnapshot::Uuid.encode()[0], 0x52);
         assert_eq!(DataTypeSnapshot::Json.encode()[0], 0x60);
-        assert_eq!(DataTypeSnapshot::Custom("x".into()).encode()[0], 0xF0);
+        assert_eq!(
+            DataTypeSnapshot::Custom(Box::new(CustomDataTypeSnapshot {
+                tag: "x".into(),
+                wire_size: WireSize::Fixed(0),
+            }))
+            .encode()[0],
+            0xF0
+        );
     }
 
     fn sample_column(name: &str) -> ColumnSnapshot {
@@ -921,7 +1047,10 @@ mod tests {
     fn test_column_snapshot_with_custom_data_type_roundtrip() {
         let col = ColumnSnapshot {
             name: "amount".to_string(),
-            data_type: DataTypeSnapshot::Custom("Money".to_string()),
+            data_type: DataTypeSnapshot::Custom(Box::new(CustomDataTypeSnapshot {
+                tag: "Money".to_string(),
+                wire_size: WireSize::Fixed(16),
+            })),
             nullable: false,
             auto_increment: false,
             unique: false,

--- a/crates/wasm-dbms/wasm-dbms-api/src/dbms/types.rs
+++ b/crates/wasm-dbms/wasm-dbms-api/src/dbms/types.rs
@@ -87,7 +87,13 @@ pub enum DataTypeKind {
     Uint32,
     Uint64,
     Uuid,
-    Custom(&'static str),
+    /// A user-defined custom type. Carries the stable [`CustomDataType::TYPE_TAG`]
+    /// and a [`crate::dbms::table::WireSize`] descriptor so the migration codec
+    /// can slice column bytes without invoking the user's `Encode::decode`.
+    Custom {
+        tag: &'static str,
+        wire_size: crate::dbms::table::WireSize,
+    },
 }
 
 #[cfg(test)]
@@ -196,22 +202,46 @@ mod test {
 
     #[test]
     fn test_should_create_custom_data_type_kind() {
-        let kind = DataTypeKind::Custom("role");
-        assert_eq!(kind, DataTypeKind::Custom("role"));
-        assert_ne!(kind, DataTypeKind::Custom("status"));
+        use crate::dbms::table::WireSize;
+        let kind = DataTypeKind::Custom {
+            tag: "role",
+            wire_size: WireSize::Fixed(1),
+        };
+        assert_eq!(
+            kind,
+            DataTypeKind::Custom {
+                tag: "role",
+                wire_size: WireSize::Fixed(1)
+            }
+        );
+        assert_ne!(
+            kind,
+            DataTypeKind::Custom {
+                tag: "status",
+                wire_size: WireSize::Fixed(1)
+            }
+        );
         assert_ne!(kind, DataTypeKind::Text);
     }
 
     #[test]
     fn test_should_copy_custom_data_type_kind() {
-        let kind = DataTypeKind::Custom("role");
+        use crate::dbms::table::WireSize;
+        let kind = DataTypeKind::Custom {
+            tag: "role",
+            wire_size: WireSize::LengthPrefixed,
+        };
         let copied = kind;
         assert_eq!(kind, copied);
     }
 
     #[test]
     fn test_should_debug_custom_data_type_kind() {
-        let kind = DataTypeKind::Custom("role");
+        use crate::dbms::table::WireSize;
+        let kind = DataTypeKind::Custom {
+            tag: "role",
+            wire_size: WireSize::Fixed(1),
+        };
         let debug = format!("{kind:?}");
         assert!(debug.contains("Custom"));
         assert!(debug.contains("role"));

--- a/crates/wasm-dbms/wasm-dbms-macros/src/table/metadata.rs
+++ b/crates/wasm-dbms/wasm-dbms-macros/src/table/metadata.rs
@@ -693,9 +693,12 @@ fn get_fields(
         ) = if custom_type {
             let custom_ident = field_type_ident.clone();
             let dtk: syn::Expr = syn::parse_quote! {
-                ::wasm_dbms_api::prelude::DataTypeKind::Custom(
-                    <#custom_ident as ::wasm_dbms_api::prelude::CustomDataType>::TYPE_TAG
-                )
+                ::wasm_dbms_api::prelude::DataTypeKind::Custom {
+                    tag: <#custom_ident as ::wasm_dbms_api::prelude::CustomDataType>::TYPE_TAG,
+                    wire_size: ::wasm_dbms_api::prelude::WireSize::from_data_size(
+                        <#custom_ident as ::wasm_dbms_api::prelude::Encode>::SIZE,
+                    ),
+                }
             };
             (dtk, None, Some(custom_ident))
         } else {

--- a/crates/wasm-dbms/wasm-dbms-macros/src/table/table_schema.rs
+++ b/crates/wasm-dbms/wasm-dbms-macros/src/table/table_schema.rs
@@ -112,7 +112,10 @@ fn column_def(metadata: &TableMetadata) -> syn::Result<TokenStream2> {
     }
 
     Ok(quote::quote! {
-        &[#(#columns),*]
+        {
+            const COLUMNS: &[::wasm_dbms_api::prelude::ColumnDef] = &[#(#columns),*];
+            COLUMNS
+        }
     })
 }
 

--- a/crates/wasm-dbms/wasm-dbms-memory/src/lib.rs
+++ b/crates/wasm-dbms/wasm-dbms-memory/src/lib.rs
@@ -29,7 +29,8 @@ pub use self::memory_manager::{MemoryManager, align_up};
 pub use self::provider::{HeapMemoryProvider, MemoryProvider, WASM_PAGE_SIZE};
 pub use self::schema_registry::{SchemaRegistry, TableRegistryPage};
 pub use self::table_registry::{
-    IndexLedger, IndexTreeWalker, NextRecord, RecordAddress, TableReader, TableRegistry,
+    IndexLedger, IndexTreeWalker, NextRecord, RawRecordBytes, RawTableReader, RecordAddress,
+    TableReader, TableRegistry,
 };
 
 /// Prelude re-exports for convenient use.
@@ -40,7 +41,7 @@ pub mod prelude {
     pub use super::provider::{HeapMemoryProvider, MemoryProvider, WASM_PAGE_SIZE};
     pub use super::schema_registry::{SchemaRegistry, TableRegistryPage};
     pub use super::table_registry::{
-        AutoincrementLedger, IndexLedger, IndexTreeWalker, NextRecord, RecordAddress, TableReader,
-        TableRegistry,
+        AutoincrementLedger, IndexLedger, IndexTreeWalker, NextRecord, RawRecordBytes,
+        RawTableReader, RecordAddress, TableReader, TableRegistry,
     };
 }

--- a/crates/wasm-dbms/wasm-dbms-memory/src/memory_access.rs
+++ b/crates/wasm-dbms/wasm-dbms-memory/src/memory_access.rs
@@ -42,6 +42,12 @@ pub trait MemoryAccess {
     where
         E: Encode;
 
+    /// Zeros out `len` raw bytes at the specified page and offset.
+    ///
+    /// Used by the migration apply pipeline when scrubbing a record whose
+    /// size is known only at runtime (from a stored snapshot).
+    fn zero_raw(&mut self, page: Page, offset: PageOffset, len: PageOffset) -> MemoryResult<()>;
+
     /// Reads raw bytes into `buf` at the specified page and offset.
     ///
     /// Returns the number of bytes actually read.

--- a/crates/wasm-dbms/wasm-dbms-memory/src/memory_manager.rs
+++ b/crates/wasm-dbms/wasm-dbms-memory/src/memory_manager.rs
@@ -223,6 +223,30 @@ where
         self.provider.write(absolute_offset, buffer.as_ref())
     }
 
+    fn zero_raw(&mut self, page: Page, offset: PageOffset, len: PageOffset) -> MemoryResult<()> {
+        if self.last_page().is_none_or(|last_page| page > last_page) {
+            return Err(MemoryError::SegmentationFault {
+                page,
+                offset,
+                data_size: len as u64,
+                page_size: P::PAGE_SIZE,
+            });
+        }
+
+        if offset as u64 + len as u64 > P::PAGE_SIZE {
+            return Err(MemoryError::SegmentationFault {
+                page,
+                offset,
+                data_size: len as u64,
+                page_size: P::PAGE_SIZE,
+            });
+        }
+
+        let absolute_offset = self.absolute_offset(page, offset);
+        let buffer = vec![0u8; len as usize];
+        self.provider.write(absolute_offset, buffer.as_ref())
+    }
+
     fn read_at_raw(
         &mut self,
         page: Page,

--- a/crates/wasm-dbms/wasm-dbms-memory/src/table_registry.rs
+++ b/crates/wasm-dbms/wasm-dbms-memory/src/table_registry.rs
@@ -5,18 +5,20 @@ mod free_segments_ledger;
 mod index_ledger;
 mod page_ledger;
 mod raw_record;
+mod raw_table_reader;
 mod record_address;
 mod schema_snapshot_ledger;
 mod table_reader;
 mod write_at;
 
-use wasm_dbms_api::prelude::{Encode, MemoryResult, PageOffset, Value};
+use wasm_dbms_api::prelude::{Encode, MSize, MemoryResult, PageOffset, Value};
 
 pub use self::autoincrement_ledger::AutoincrementLedger;
 use self::free_segments_ledger::FreeSegmentsLedger;
 pub use self::index_ledger::{IndexLedger, IndexTreeWalker};
 use self::page_ledger::PageLedger;
 use self::raw_record::RawRecord;
+pub use self::raw_table_reader::{RawRecordBytes, RawTableReader};
 pub use self::record_address::RecordAddress;
 pub use self::schema_snapshot_ledger::SchemaSnapshotLedger;
 pub use self::table_reader::{NextRecord, TableReader};
@@ -154,6 +156,113 @@ impl TableRegistry {
         }
     }
 
+    /// Iterate the table's records as raw bytes under the given alignment.
+    ///
+    /// Used by the migration apply pipeline to read records under the stored
+    /// snapshot. `alignment` must match the on-disk layout (i.e. the
+    /// `TableSchemaSnapshot::alignment` of the snapshot the records were
+    /// inserted under).
+    pub fn iter_raw<'a, MA>(
+        &'a self,
+        alignment: PageOffset,
+        mm: &'a mut MA,
+    ) -> RawTableReader<'a, MA>
+    where
+        MA: MemoryAccess,
+    {
+        RawTableReader::new(&self.page_ledger, alignment, mm)
+    }
+
+    /// Insert pre-encoded record bytes under the given alignment.
+    ///
+    /// Used by the migration apply pipeline. `bytes` is the body of the
+    /// record (without the 2-byte length header — the registry writes the
+    /// header). `alignment` comes from the target snapshot.
+    pub fn insert_raw(
+        &mut self,
+        bytes: &[u8],
+        alignment: PageOffset,
+        mm: &mut impl MemoryAccess,
+    ) -> MemoryResult<RecordAddress> {
+        use self::raw_record::RAW_RECORD_HEADER_SIZE;
+
+        let length = bytes.len() as MSize;
+        let total = (RAW_RECORD_HEADER_SIZE + length) as u64;
+        let physical_size_msize = align_up_msize(RAW_RECORD_HEADER_SIZE + length, alignment);
+        let physical_size_u64 = physical_size_msize as u64;
+
+        // Reuse a free segment if one fits.
+        let (page, offset) = if let Some(segment) = self
+            .free_segments_ledger
+            .find_reusable_segment_raw(length, mm)?
+        {
+            let page = segment.segment.page;
+            let offset = segment.segment.offset;
+            self.free_segments_ledger
+                .commit_reused_space_raw(physical_size_msize, segment, mm)?;
+            (page, offset)
+        } else {
+            let (page, offset) = self
+                .page_ledger
+                .get_page_and_offset_raw(physical_size_u64, mm)?;
+            self.page_ledger.commit_raw(page, total, alignment, mm)?;
+            (page, offset)
+        };
+
+        let aligned_offset = align_up_msize(offset, alignment);
+        let mut full = Vec::with_capacity(total as usize);
+        full.extend_from_slice(&length.to_le_bytes());
+        full.extend_from_slice(bytes);
+        mm.write_at_raw(page, aligned_offset, &full)?;
+
+        Ok(RecordAddress {
+            page,
+            offset: aligned_offset,
+        })
+    }
+
+    /// Read raw record bytes at the given address (header stripped).
+    pub fn read_raw_at(
+        &self,
+        address: RecordAddress,
+        mm: &mut impl MemoryAccess,
+    ) -> MemoryResult<Vec<u8>> {
+        use self::raw_record::RAW_RECORD_HEADER_SIZE;
+
+        let mut header = [0u8; RAW_RECORD_HEADER_SIZE as usize];
+        mm.read_at_raw(address.page, address.offset, &mut header)?;
+        let length = u16::from_le_bytes(header) as usize;
+        let mut body = vec![0u8; length];
+        mm.read_at_raw(
+            address.page,
+            address.offset + RAW_RECORD_HEADER_SIZE,
+            &mut body,
+        )?;
+        Ok(body)
+    }
+
+    /// Delete a raw record at the given address. Mirrors [`Self::delete`]
+    /// but parameterises size + alignment rather than reading them from a
+    /// compile-time `Encode` impl.
+    pub fn delete_raw(
+        &mut self,
+        address: RecordAddress,
+        body_len: MSize,
+        alignment: PageOffset,
+        mm: &mut impl MemoryAccess,
+    ) -> MemoryResult<()> {
+        use self::raw_record::RAW_RECORD_HEADER_SIZE;
+
+        let physical_size = align_up_msize(RAW_RECORD_HEADER_SIZE + body_len, alignment);
+        mm.zero_raw(address.page, address.offset, physical_size)?;
+        self.free_segments_ledger.insert_free_segment_raw(
+            address.page,
+            address.offset,
+            physical_size,
+            mm,
+        )
+    }
+
     /// Get a reference to the index ledger, allowing to read the indexes.
     pub fn index_ledger(&self) -> &IndexLedger {
         &self.index_ledger
@@ -271,6 +380,16 @@ impl TableRegistry {
             }
         }
     }
+}
+
+/// Round `value` up to the next multiple of `alignment`. Runtime sibling
+/// to the const [`align_up`](crate::align_up) helper. Used by the raw
+/// insert/delete path where alignment comes from a stored snapshot.
+fn align_up_msize(value: MSize, alignment: PageOffset) -> MSize {
+    if alignment == 0 {
+        return value;
+    }
+    value.div_ceil(alignment) * alignment
 }
 
 /// Test utilities shared across the table_registry submodules.

--- a/crates/wasm-dbms/wasm-dbms-memory/src/table_registry/free_segments_ledger.rs
+++ b/crates/wasm-dbms/wasm-dbms-memory/src/table_registry/free_segments_ledger.rs
@@ -155,6 +155,71 @@ impl FreeSegmentsLedger {
         table.remove(segment.segment, physical_size, mm)
     }
 
+    /// Inserts a free segment with a runtime-known physical size.
+    ///
+    /// Sibling to [`Self::insert_free_segment`], used by the migration apply
+    /// pipeline when releasing a record whose alignment came from a stored
+    /// snapshot rather than a compile-time `Encode` impl.
+    pub fn insert_free_segment_raw(
+        &mut self,
+        page: Page,
+        offset: PageOffset,
+        physical_size: MSize,
+        mm: &mut impl MemoryAccess,
+    ) -> MemoryResult<()> {
+        for table in self.tables(mm) {
+            let mut table = table?;
+            if !table.is_full() {
+                return table.insert_free_segment(page, offset, physical_size, mm);
+            }
+        }
+
+        let new_page = self.create_new_page(mm)?;
+        let mut table = FreeSegmentsTable::load(new_page, mm)?;
+        table.insert_free_segment(page, offset, physical_size, mm)
+    }
+
+    /// Find a reusable free segment for a record of `required_size` bytes.
+    /// Sibling to [`Self::find_reusable_segment`].
+    pub fn find_reusable_segment_raw(
+        &self,
+        required_size: MSize,
+        mm: &mut impl MemoryAccess,
+    ) -> MemoryResult<Option<FreeSegmentTicket>> {
+        for table in self.tables(mm) {
+            let table = table?;
+            if let Some(segment) = table.find(|r| r.size >= required_size) {
+                return Ok(Some(FreeSegmentTicket {
+                    segment,
+                    table: table.page(),
+                }));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Commit a reused segment with a runtime-known physical size.
+    /// Sibling to [`Self::commit_reused_space`].
+    pub fn commit_reused_space_raw(
+        &mut self,
+        physical_size: MSize,
+        segment: FreeSegmentTicket,
+        mm: &mut impl MemoryAccess,
+    ) -> MemoryResult<()> {
+        let mut table = None;
+        for i_table in self.tables(mm) {
+            let i_table = i_table?;
+            if i_table.page() == segment.table {
+                table = Some(i_table);
+                break;
+            }
+        }
+        let Some(mut table) = table else {
+            return Err(MemoryError::OutOfBounds);
+        };
+        table.remove(segment.segment, physical_size, mm)
+    }
+
     /// Writes the current state of the free segments table back to memory.
     fn commit(&self, mm: &mut impl MemoryAccess) -> MemoryResult<()> {
         mm.write_at(self.free_segments_page, 0, &self.tables)

--- a/crates/wasm-dbms/wasm-dbms-memory/src/table_registry/page_ledger.rs
+++ b/crates/wasm-dbms/wasm-dbms-memory/src/table_registry/page_ledger.rs
@@ -105,6 +105,70 @@ impl PageLedger {
         Err(wasm_dbms_api::prelude::MemoryError::OutOfBounds)
     }
 
+    /// Find page + offset for a record of `physical_size` bytes (header
+    /// included, padded to alignment). Used by the migration apply pipeline,
+    /// which knows record size only at runtime via the stored snapshot.
+    pub fn get_page_and_offset_raw(
+        &mut self,
+        physical_size: u64,
+        mm: &mut impl MemoryAccess,
+    ) -> MemoryResult<(Page, PageOffset)> {
+        let page_size = mm.page_size();
+        if physical_size > page_size {
+            return Err(wasm_dbms_api::prelude::MemoryError::DataTooLarge {
+                page_size,
+                requested: physical_size,
+            });
+        }
+
+        let next_page = self.pages.pages.iter().find(|page_record| {
+            let taken = page_size.saturating_sub(page_record.free);
+            taken + physical_size <= page_size
+        });
+        if let Some(page_record) = next_page {
+            let offset = page_size.saturating_sub(page_record.free) as PageOffset;
+            return Ok((page_record.page, offset));
+        }
+
+        let new_page = mm.allocate_page()?;
+        self.pages.pages.push(PageRecord {
+            page: new_page,
+            free: page_size,
+        });
+
+        Ok((new_page, 0))
+    }
+
+    /// Commit a raw allocation of `record_size` bytes (header included),
+    /// padded to `alignment`. Sibling to [`Self::commit`] for the migration
+    /// apply pipeline.
+    pub fn commit_raw(
+        &mut self,
+        page: Page,
+        record_size: u64,
+        alignment: PageOffset,
+        mm: &mut impl MemoryAccess,
+    ) -> MemoryResult<()> {
+        if let Some(page_record) = self.pages.pages.iter_mut().find(|pr| pr.page == page) {
+            if page_record.free < record_size {
+                return Err(wasm_dbms_api::prelude::MemoryError::DataTooLarge {
+                    page_size: page_record.free,
+                    requested: record_size,
+                });
+            }
+            let alignment = alignment as u64;
+            let padded = if alignment == 0 {
+                record_size
+            } else {
+                record_size.div_ceil(alignment) * alignment
+            };
+            page_record.free = page_record.free.saturating_sub(padded);
+            self.write(mm)?;
+            return Ok(());
+        }
+        Err(wasm_dbms_api::prelude::MemoryError::OutOfBounds)
+    }
+
     /// Returns the list of pages in the ledger.
     pub fn pages(&self) -> &[PageRecord] {
         &self.pages.pages

--- a/crates/wasm-dbms/wasm-dbms-memory/src/table_registry/raw_table_reader.rs
+++ b/crates/wasm-dbms/wasm-dbms-memory/src/table_registry/raw_table_reader.rs
@@ -1,0 +1,261 @@
+// Rust guideline compliant 2026-04-27
+
+//! Raw-bytes table reader.
+//!
+//! Mirrors [`TableReader`](super::TableReader) but yields the encoded record
+//! bytes plus its [`RecordAddress`], so callers can decode via a snapshot-
+//! driven decoder (used by the migration apply pipeline to read records
+//! under the **stored** snapshot independent of the compile-time `T`).
+
+use wasm_dbms_api::prelude::{DecodeError, MSize, MemoryError, MemoryResult, Page, PageOffset};
+
+use super::page_ledger::PageLedger;
+use super::raw_record::RAW_RECORD_HEADER_SIZE;
+use super::record_address::RecordAddress;
+use crate::MemoryAccess;
+
+/// Yielded by [`RawTableReader::try_next`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawRecordBytes {
+    /// Address of the record (page + aligned offset to the length header).
+    pub address: RecordAddress,
+    /// Decoded record body bytes (header stripped).
+    pub bytes: Vec<u8>,
+}
+
+/// Iterator over a table's records as raw bytes. Mirrors the scan logic of
+/// [`TableReader`](super::TableReader) but parameterised over runtime
+/// alignment (the migration codec slices records by snapshot, not by `T`).
+pub struct RawTableReader<'a, MA>
+where
+    MA: MemoryAccess,
+{
+    mm: &'a mut MA,
+    page_ledger: &'a PageLedger,
+    page_size: usize,
+    alignment: PageOffset,
+    cursor: Option<Cursor>,
+}
+
+#[derive(Debug, Copy, Clone)]
+struct Cursor {
+    page: Page,
+    offset: PageOffset,
+}
+
+impl<'a, MA> RawTableReader<'a, MA>
+where
+    MA: MemoryAccess,
+{
+    /// Build a reader. `alignment` must be the table's record alignment as
+    /// stored in the snapshot (matches the on-disk layout written by
+    /// `TableRegistry::insert`).
+    pub fn new(page_ledger: &'a PageLedger, alignment: PageOffset, mm: &'a mut MA) -> Self {
+        let page_size = mm.page_size() as usize;
+        let cursor = page_ledger.pages().first().map(|p| Cursor {
+            page: p.page,
+            offset: 0,
+        });
+        Self {
+            mm,
+            page_ledger,
+            page_size,
+            alignment,
+            cursor,
+        }
+    }
+
+    /// Pop the next live record's bytes, or `Ok(None)` at end of table.
+    pub fn try_next(&mut self) -> MemoryResult<Option<RawRecordBytes>> {
+        loop {
+            let Some(Cursor { page, offset }) = self.cursor else {
+                return Ok(None);
+            };
+            let aligned_usize = align_up_usize(offset as usize, self.alignment as usize);
+            // No room for a header on this page → advance to next page.
+            if aligned_usize + (RAW_RECORD_HEADER_SIZE as usize) > self.page_size {
+                self.cursor = self.next_page(page);
+                continue;
+            }
+            let aligned = aligned_usize as PageOffset;
+            let mut header = [0u8; RAW_RECORD_HEADER_SIZE as usize];
+            self.mm.read_at_raw(page, aligned, &mut header)?;
+            let length = u16::from_le_bytes(header) as MSize;
+            if length == 0 {
+                // Empty slot — skip one alignment.
+                let next_offset = aligned_usize + self.alignment as usize;
+                self.cursor = if next_offset >= self.page_size {
+                    self.next_page(page)
+                } else {
+                    Some(Cursor {
+                        page,
+                        offset: next_offset as PageOffset,
+                    })
+                };
+                continue;
+            }
+            let body_offset_usize = aligned_usize + RAW_RECORD_HEADER_SIZE as usize;
+            if body_offset_usize + (length as usize) > self.page_size {
+                return Err(MemoryError::DecodeError(DecodeError::TooShort));
+            }
+            let body_offset = body_offset_usize as PageOffset;
+            let mut body = vec![0u8; length as usize];
+            self.mm.read_at_raw(page, body_offset, &mut body)?;
+            let address = RecordAddress {
+                page,
+                offset: aligned,
+            };
+            // Advance past the record body, aligned to the next slot.
+            let next_offset =
+                align_up_usize(body_offset_usize + length as usize, self.alignment as usize);
+            self.cursor = if next_offset >= self.page_size {
+                self.next_page(page)
+            } else {
+                Some(Cursor {
+                    page,
+                    offset: next_offset as PageOffset,
+                })
+            };
+            return Ok(Some(RawRecordBytes {
+                address,
+                bytes: body,
+            }));
+        }
+    }
+
+    fn next_page(&self, current: Page) -> Option<Cursor> {
+        self.page_ledger
+            .pages()
+            .iter()
+            .find(|p| p.page > current)
+            .map(|p| Cursor {
+                page: p.page,
+                offset: 0,
+            })
+    }
+}
+
+fn align_up_usize(offset: usize, alignment: usize) -> usize {
+    if alignment == 0 {
+        return offset;
+    }
+    let rem = offset % alignment;
+    if rem == 0 {
+        offset
+    } else {
+        offset + (alignment - rem)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::table_registry::test_utils::{User, write_dummy_schema_snapshot};
+    use crate::{HeapMemoryProvider, MemoryManager, TableRegistry, TableRegistryPage};
+
+    #[test]
+    fn test_insert_raw_round_trips_through_raw_reader() {
+        let mut mm = MemoryManager::init(HeapMemoryProvider::default());
+        let schema_snapshot_page = mm.allocate_page().unwrap();
+        let pages_list_page = mm.allocate_page().unwrap();
+        let free_segments_page = mm.allocate_page().unwrap();
+        let index_registry_page = mm.allocate_page().unwrap();
+        write_dummy_schema_snapshot(schema_snapshot_page, &mut mm);
+
+        let mut registry = TableRegistry::load(
+            TableRegistryPage {
+                schema_snapshot_page,
+                pages_list_page,
+                free_segments_page,
+                index_registry_page,
+                autoincrement_registry_page: None,
+            },
+            &mut mm,
+        )
+        .unwrap();
+
+        let alignment = 32u16;
+        let payload = vec![1u8, 2, 3, 4, 5, 6, 7];
+        let address = registry.insert_raw(&payload, alignment, &mut mm).unwrap();
+        let read_back = registry.read_raw_at(address, &mut mm).unwrap();
+        assert_eq!(read_back, payload);
+
+        let mut reader = RawTableReader::new(&registry.page_ledger, alignment, &mut mm);
+        let row = reader.try_next().unwrap().expect("missing row");
+        assert_eq!(row.bytes, payload);
+        assert!(reader.try_next().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_delete_raw_frees_segment() {
+        let mut mm = MemoryManager::init(HeapMemoryProvider::default());
+        let schema_snapshot_page = mm.allocate_page().unwrap();
+        let pages_list_page = mm.allocate_page().unwrap();
+        let free_segments_page = mm.allocate_page().unwrap();
+        let index_registry_page = mm.allocate_page().unwrap();
+        write_dummy_schema_snapshot(schema_snapshot_page, &mut mm);
+
+        let mut registry = TableRegistry::load(
+            TableRegistryPage {
+                schema_snapshot_page,
+                pages_list_page,
+                free_segments_page,
+                index_registry_page,
+                autoincrement_registry_page: None,
+            },
+            &mut mm,
+        )
+        .unwrap();
+
+        let alignment = 32u16;
+        let bytes = vec![9u8; 10];
+        let addr = registry.insert_raw(&bytes, alignment, &mut mm).unwrap();
+        registry
+            .delete_raw(addr, bytes.len() as MSize, alignment, &mut mm)
+            .unwrap();
+
+        let mut reader = RawTableReader::new(&registry.page_ledger, alignment, &mut mm);
+        assert!(reader.try_next().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_raw_table_reader_reads_all_records_as_bytes() {
+        use wasm_dbms_api::prelude::Encode;
+
+        let mut mm = MemoryManager::init(HeapMemoryProvider::default());
+        let schema_snapshot_page = mm.allocate_page().unwrap();
+        let pages_list_page = mm.allocate_page().unwrap();
+        let free_segments_page = mm.allocate_page().unwrap();
+        let index_registry_page = mm.allocate_page().unwrap();
+        write_dummy_schema_snapshot(schema_snapshot_page, &mut mm);
+
+        let mut registry = TableRegistry::load(
+            TableRegistryPage {
+                schema_snapshot_page,
+                pages_list_page,
+                free_segments_page,
+                index_registry_page,
+                autoincrement_registry_page: None,
+            },
+            &mut mm,
+        )
+        .unwrap();
+
+        for id in 0..3u32 {
+            let user = User {
+                id,
+                name: format!("U{id}"),
+                email: "x@x".into(),
+                age: 20,
+            };
+            registry.insert(user, &mut mm).unwrap();
+        }
+
+        let mut reader = RawTableReader::new(&registry.page_ledger, User::ALIGNMENT, &mut mm);
+        let mut count = 0;
+        while reader.try_next().unwrap().is_some() {
+            count += 1;
+        }
+        assert_eq!(count, 3);
+    }
+}

--- a/crates/wasm-dbms/wasm-dbms/src/database/migration.rs
+++ b/crates/wasm-dbms/wasm-dbms/src/database/migration.rs
@@ -11,6 +11,8 @@
 //! design context.
 
 pub(crate) mod apply;
+pub(crate) mod codec;
 pub(crate) mod diff;
 pub(crate) mod plan;
 pub(crate) mod snapshots;
+pub(crate) mod widen;

--- a/crates/wasm-dbms/wasm-dbms/src/database/migration/apply.rs
+++ b/crates/wasm-dbms/wasm-dbms/src/database/migration/apply.rs
@@ -15,21 +15,25 @@
 //!   currently leaked (issue #90 tracks reclamation).
 //! - `AlterColumn` — snapshot-only edit, plus tightening validation through
 //!   the schema dispatch.
-//! - `AddIndex` / `DropIndex` — snapshot-only edit; index population from
-//!   existing rows is deferred to the snapshot-driven I/O follow-up.
+//! - `AddIndex` / `DropIndex` — snapshot edit plus index-ledger refresh from
+//!   live rows.
 //!
 //! Column-mutating ops (`AddColumn`, `DropColumn`, `RenameColumn`,
-//! `WidenColumn`, `TransformColumn`) require a snapshot-driven record
-//! (de)serializer that does not yet exist; they return
-//! [`MigrationError::DataRewriteUnsupported`] so callers see a clear,
-//! recoverable error and can defer the migration until issue #91 lands.
+//! `WidenColumn`, `TransformColumn`) use the snapshot-driven record codec
+//! (see [`super::codec`]) and the [`rewrite_table`] helper to walk every
+//! record under the stored snapshot and re-encode it under the target
+//! snapshot. Indexes are rebuilt from scratch after the rewrite.
 
 use wasm_dbms_api::prelude::{
-    ColumnChanges, DbmsError, DbmsResult, MigrationError, MigrationOp, Query, TableSchemaSnapshot,
+    ColumnChanges, ColumnSnapshot, DataTypeSnapshot, DbmsError, DbmsResult, Filter,
+    ForeignKeySnapshot, MSize, MigrationError, MigrationOp, Query, TableSchemaSnapshot, Value,
 };
-use wasm_dbms_memory::prelude::{AccessControl, MemoryProvider};
+use wasm_dbms_memory::TableRegistry;
+use wasm_dbms_memory::prelude::{AccessControl, IndexLedger, MemoryProvider};
 
 use crate::database::WasmDbmsDatabase;
+use crate::database::migration::codec::{decode_record_by_snapshot, encode_record_by_snapshot};
+use crate::database::migration::widen::widen_value;
 
 /// Applies `ops` to the database under the existing journal.
 ///
@@ -94,18 +98,24 @@ where
         } => alter_column(db, &table, &column, &changes, touched),
         MigrationOp::AddIndex { table, index } => add_index(db, &table, &index, touched),
         MigrationOp::DropIndex { table, index } => drop_index(db, &table, &index, touched),
-        MigrationOp::AddColumn { .. } => unsupported("AddColumn"),
-        MigrationOp::DropColumn { .. } => unsupported("DropColumn"),
-        MigrationOp::RenameColumn { .. } => unsupported("RenameColumn"),
-        MigrationOp::WidenColumn { .. } => unsupported("WidenColumn"),
-        MigrationOp::TransformColumn { .. } => unsupported("TransformColumn"),
+        MigrationOp::AddColumn { table, column } => add_column(db, &table, &column, touched),
+        MigrationOp::DropColumn { table, column } => drop_column(db, &table, &column, touched),
+        MigrationOp::RenameColumn { table, old, new } => {
+            rename_column(db, &table, &old, &new, touched)
+        }
+        MigrationOp::WidenColumn {
+            table,
+            column,
+            old_type,
+            new_type,
+        } => widen_column(db, &table, &column, &old_type, &new_type, touched),
+        MigrationOp::TransformColumn {
+            table,
+            column,
+            old_type,
+            new_type,
+        } => transform_column(db, &table, &column, &old_type, &new_type, touched),
     }
-}
-
-fn unsupported(op: &str) -> DbmsResult<()> {
-    Err(DbmsError::Migration(
-        MigrationError::DataRewriteUnsupported { op: op.to_string() },
-    ))
 }
 
 fn create_table<M, A>(
@@ -176,10 +186,68 @@ where
         target.primary_key = value;
     }
     if let Some(fk) = &changes.foreign_key {
+        if let Some(new_fk) = fk {
+            validate_foreign_key(db, table, column, new_fk)?;
+        }
         target.foreign_key = fk.clone();
     }
 
     persist_pending_snapshot(touched, snapshot);
+    Ok(())
+}
+
+/// Validate that every non-null value in `(table, column)` is present in
+/// `(fk.table, fk.column)`. Runs before the snapshot edit so a violation
+/// rolls back the entire apply pass.
+fn validate_foreign_key<M, A>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+    column: &str,
+    fk: &ForeignKeySnapshot,
+) -> DbmsResult<()>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    let rows = db.schema.select(db, table, Query::builder().build())?;
+    for row in rows {
+        let Some((_, value)) = row.iter().find(|(c, _)| c.name == column) else {
+            continue;
+        };
+        if matches!(value, Value::Null) {
+            continue;
+        }
+        validate_foreign_key_value(db, table, column, fk, value)?;
+    }
+    Ok(())
+}
+
+fn validate_foreign_key_value<M, A>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+    column: &str,
+    fk: &ForeignKeySnapshot,
+    value: &Value,
+) -> DbmsResult<()>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    let target_rows = db.schema.select(
+        db,
+        &fk.table,
+        Query::builder()
+            .filter(Some(Filter::eq(&fk.column, value.clone())))
+            .build(),
+    )?;
+    if target_rows.is_empty() {
+        return Err(DbmsError::Migration(MigrationError::ForeignKeyViolation {
+            table: table.to_string(),
+            column: column.to_string(),
+            target_table: fk.table.clone(),
+            value: format!("{value:?}"),
+        }));
+    }
     Ok(())
 }
 
@@ -196,6 +264,7 @@ where
     let mut snapshot = load_snapshot_for_mutation(db, table, touched)?;
     if !snapshot.indexes.iter().any(|i| i == index) {
         snapshot.indexes.push(index.clone());
+        rebuild_indexes_from_storage(db, table, &snapshot)?;
     }
     persist_pending_snapshot(touched, snapshot);
     Ok(())
@@ -214,6 +283,393 @@ where
     let mut snapshot = load_snapshot_for_mutation(db, table, touched)?;
     snapshot.indexes.retain(|i| i != index);
     persist_pending_snapshot(touched, snapshot);
+    Ok(())
+}
+
+/// Resolve the default value for a freshly added column.
+///
+/// Resolution order:
+/// 1. `Migrate::default_value` hook on the schema dispatch.
+/// 2. `#[default]` attribute baked into the column snapshot.
+/// 3. `Value::Null` if the column is nullable.
+/// 4. Otherwise, [`MigrationError::DefaultMissing`].
+fn resolve_default<M, A>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+    column: &ColumnSnapshot,
+) -> DbmsResult<Value>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    if let Some(v) = db.schema.migrate_default_dyn(table, &column.name) {
+        return Ok(v);
+    }
+    if let Some(v) = column.default.clone() {
+        return Ok(v);
+    }
+    if column.nullable {
+        return Ok(Value::Null);
+    }
+    Err(DbmsError::Migration(MigrationError::DefaultMissing {
+        table: table.to_string(),
+        column: column.name.clone(),
+    }))
+}
+
+/// Transform `column` via [`Migrate::transform_column`] for each row.
+///
+/// `Ok(Some(v))` — use the new value.
+/// `Ok(None)` — error with [`MigrationError::TransformReturnedNone`] (the
+/// caller could have used `WidenColumn` if the type pair were widening).
+/// `Err(_)` — propagate; the journal session rolls back.
+fn transform_column<M, A>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+    column: &str,
+    _old_type: &DataTypeSnapshot,
+    new_type: &DataTypeSnapshot,
+    touched: &mut Vec<TableSchemaSnapshot>,
+) -> DbmsResult<()>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    let old_snapshot = load_snapshot_for_mutation(db, table, touched)?;
+    if !old_snapshot.columns.iter().any(|c| c.name == column) {
+        return Err(DbmsError::Migration(MigrationError::ConstraintViolation {
+            table: table.to_string(),
+            column: column.to_string(),
+            reason: "column not present in stored snapshot".to_string(),
+        }));
+    }
+    let mut new_snapshot = old_snapshot.clone();
+    if let Some(col) = new_snapshot.columns.iter_mut().find(|c| c.name == column) {
+        col.data_type = new_type.clone();
+    }
+    let table_owned = table.to_string();
+    let column_owned = column.to_string();
+
+    rewrite_table(db, table, &old_snapshot, &new_snapshot, |values| {
+        values
+            .into_iter()
+            .map(|(n, v)| {
+                if n != column_owned {
+                    return Ok((n, v));
+                }
+                if matches!(v, Value::Null) {
+                    return Ok((n, Value::Null));
+                }
+                let new_value = db
+                    .schema
+                    .migrate_transform_dyn(&table_owned, &column_owned, v)?;
+                match new_value {
+                    Some(new_value) => Ok((n, new_value)),
+                    None => Err(DbmsError::Migration(
+                        MigrationError::TransformReturnedNone {
+                            table: table_owned.clone(),
+                            column: column_owned.clone(),
+                        },
+                    )),
+                }
+            })
+            .collect::<DbmsResult<Vec<(String, Value)>>>()
+    })?;
+    persist_pending_snapshot(touched, new_snapshot);
+    Ok(())
+}
+
+/// Widen `column` in `table` from `old_type` to `new_type` using the
+/// compatible-widening whitelist. Each record's value for the column is
+/// replaced with its widened equivalent.
+fn widen_column<M, A>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+    column: &str,
+    old_type: &DataTypeSnapshot,
+    new_type: &DataTypeSnapshot,
+    touched: &mut Vec<TableSchemaSnapshot>,
+) -> DbmsResult<()>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    let old_snapshot = load_snapshot_for_mutation(db, table, touched)?;
+    if !old_snapshot.columns.iter().any(|c| c.name == column) {
+        return Err(DbmsError::Migration(MigrationError::ConstraintViolation {
+            table: table.to_string(),
+            column: column.to_string(),
+            reason: "column not present in stored snapshot".to_string(),
+        }));
+    }
+    let mut new_snapshot = old_snapshot.clone();
+    if let Some(col) = new_snapshot.columns.iter_mut().find(|c| c.name == column) {
+        col.data_type = new_type.clone();
+    }
+    let table_owned = table.to_string();
+    let column_owned = column.to_string();
+    let old_dt = old_type.clone();
+    let new_dt = new_type.clone();
+    rewrite_table(db, table, &old_snapshot, &new_snapshot, |values| {
+        values
+            .into_iter()
+            .map(|(n, v)| {
+                if n == column_owned {
+                    let widened = widen_value(&table_owned, &column_owned, &old_dt, &new_dt, v)?;
+                    Ok((n, widened))
+                } else {
+                    Ok((n, v))
+                }
+            })
+            .collect::<DbmsResult<Vec<(String, Value)>>>()
+    })?;
+    persist_pending_snapshot(touched, new_snapshot);
+    Ok(())
+}
+
+/// Rename `old` → `new` in `table`. Each record's column-keyed tuple is
+/// rewritten with the new key; data is preserved verbatim.
+fn rename_column<M, A>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+    old: &str,
+    new: &str,
+    touched: &mut Vec<TableSchemaSnapshot>,
+) -> DbmsResult<()>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    let old_snapshot = load_snapshot_for_mutation(db, table, touched)?;
+    if !old_snapshot.columns.iter().any(|c| c.name == old) {
+        return Err(DbmsError::Migration(MigrationError::ConstraintViolation {
+            table: table.to_string(),
+            column: old.to_string(),
+            reason: "column not present in stored snapshot".to_string(),
+        }));
+    }
+    let mut new_snapshot = old_snapshot.clone();
+    if let Some(col) = new_snapshot.columns.iter_mut().find(|c| c.name == old) {
+        col.name = new.to_string();
+    }
+    let old_owned = old.to_string();
+    let new_owned = new.to_string();
+    rewrite_table(db, table, &old_snapshot, &new_snapshot, |values| {
+        Ok(values
+            .into_iter()
+            .map(|(n, v)| {
+                if n == old_owned {
+                    (new_owned.clone(), v)
+                } else {
+                    (n, v)
+                }
+            })
+            .collect())
+    })?;
+    persist_pending_snapshot(touched, new_snapshot);
+    Ok(())
+}
+
+/// Drop `column` from `table`. Each existing record is rewritten without
+/// the column's value; the snapshot mutation is published into `touched`.
+fn drop_column<M, A>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+    column: &str,
+    touched: &mut Vec<TableSchemaSnapshot>,
+) -> DbmsResult<()>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    let old_snapshot = load_snapshot_for_mutation(db, table, touched)?;
+    if !old_snapshot.columns.iter().any(|c| c.name == column) {
+        return Err(DbmsError::Migration(MigrationError::ConstraintViolation {
+            table: table.to_string(),
+            column: column.to_string(),
+            reason: "column not present in stored snapshot".to_string(),
+        }));
+    }
+    let mut new_snapshot = old_snapshot.clone();
+    new_snapshot.columns.retain(|c| c.name != column);
+    let column_owned = column.to_string();
+
+    rewrite_table(db, table, &old_snapshot, &new_snapshot, |values| {
+        Ok(values
+            .into_iter()
+            .filter(|(n, _)| n != &column_owned)
+            .collect())
+    })?;
+
+    persist_pending_snapshot(touched, new_snapshot);
+    Ok(())
+}
+
+/// Append `column` to `table` and back-fill every existing record with its
+/// resolved default. Snapshot mutation is published into `touched` so the
+/// final commit pass writes the new shape to the snapshot ledger.
+fn add_column<M, A>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+    column: &ColumnSnapshot,
+    touched: &mut Vec<TableSchemaSnapshot>,
+) -> DbmsResult<()>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    let old_snapshot = load_snapshot_for_mutation(db, table, touched)?;
+    let mut new_snapshot = old_snapshot.clone();
+    new_snapshot.columns.push(column.clone());
+
+    // Resolve default outside the rewrite borrow scope.
+    let default = resolve_default(db, table, column)?;
+    validate_added_column_constraints(db, table, column, &default)?;
+    let column_name = column.name.clone();
+
+    rewrite_table(db, table, &old_snapshot, &new_snapshot, |mut values| {
+        values.push((column_name.clone(), default.clone()));
+        Ok(values)
+    })?;
+
+    persist_pending_snapshot(touched, new_snapshot);
+    Ok(())
+}
+
+/// Validate that `AddColumn` can backfill existing rows without violating the
+/// constraints declared on the new column.
+fn validate_added_column_constraints<M, A>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+    column: &ColumnSnapshot,
+    default: &Value,
+) -> DbmsResult<()>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    if !column.nullable && matches!(default, Value::Null) {
+        return Err(DbmsError::Migration(MigrationError::ConstraintViolation {
+            table: table.to_string(),
+            column: column.name.clone(),
+            reason: "backfill default resolves to NULL for new NOT NULL column".to_string(),
+        }));
+    }
+
+    let row_count = count_rows(db, table)?;
+    if column.unique && row_count > 1 {
+        return Err(DbmsError::Migration(MigrationError::ConstraintViolation {
+            table: table.to_string(),
+            column: column.name.clone(),
+            reason: "backfill default would duplicate values for new UNIQUE column".to_string(),
+        }));
+    }
+
+    if let Some(fk) = &column.foreign_key
+        && !matches!(default, Value::Null)
+    {
+        validate_foreign_key_value(db, table, &column.name, fk, default)?;
+    }
+
+    Ok(())
+}
+
+/// Read every live record under `old_snapshot`, run `project` over the
+/// decoded column-value list, and re-insert under `new_snapshot`. Index
+/// rebuild is deferred to the apply pass's commit step.
+///
+/// Runs inside the existing journal session opened by `apply`, so any
+/// failure rolls back every page touched by the rewrite.
+fn rewrite_table<M, A, F>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+    old_snapshot: &TableSchemaSnapshot,
+    new_snapshot: &TableSchemaSnapshot,
+    mut project: F,
+) -> DbmsResult<()>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+    F: FnMut(Vec<(String, Value)>) -> DbmsResult<Vec<(String, Value)>>,
+{
+    let pages = table_registry_pages(db, table)?;
+    let raw_rows = load_raw_rows(db, table, old_snapshot)?;
+    let mut mm = db.ctx.mm.borrow_mut();
+    let mut registry = TableRegistry::load(pages, &mut *mm)?;
+
+    let mut new_rows: Vec<(wasm_dbms_memory::RecordAddress, Vec<(String, Value)>)> = Vec::new();
+    for row in raw_rows {
+        let values = decode_record_by_snapshot(&row.bytes, old_snapshot)?;
+        let projected = project(values)?;
+        let new_bytes = encode_record_by_snapshot(&projected, new_snapshot)?;
+        registry.delete_raw(
+            row.address,
+            row.bytes.len() as MSize,
+            old_snapshot.alignment as u16,
+            &mut *mm,
+        )?;
+        let new_address =
+            registry.insert_raw(&new_bytes, new_snapshot.alignment as u16, &mut *mm)?;
+        new_rows.push((new_address, projected));
+    }
+
+    rebuild_indexes(&pages, new_snapshot, &new_rows, &mut *mm)?;
+    Ok(())
+}
+
+/// Rebuild indexes for `snapshot` by scanning the current live rows stored for
+/// `table`.
+fn rebuild_indexes_from_storage<M, A>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+    snapshot: &TableSchemaSnapshot,
+) -> DbmsResult<()>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    let pages = table_registry_pages(db, table)?;
+    let rows = load_live_rows(db, table, snapshot)?;
+    let mut mm = db.ctx.mm.borrow_mut();
+    rebuild_indexes(&pages, snapshot, &rows, &mut *mm)
+}
+
+/// Re-initialise the table's index ledger and re-populate every surviving
+/// index from `new_rows`. Called at the end of [`rewrite_table`] after every
+/// record has been delete+insert-rewritten under the new snapshot.
+fn rebuild_indexes<MA>(
+    pages: &wasm_dbms_memory::prelude::TableRegistryPage,
+    new_snapshot: &TableSchemaSnapshot,
+    new_rows: &[(wasm_dbms_memory::RecordAddress, Vec<(String, Value)>)],
+    mm: &mut MA,
+) -> DbmsResult<()>
+where
+    MA: wasm_dbms_memory::MemoryAccess,
+{
+    let key_specs: Vec<Vec<String>> = new_snapshot
+        .indexes
+        .iter()
+        .map(|idx| idx.columns.clone())
+        .collect();
+    IndexLedger::init_from_keys(pages.index_registry_page, key_specs.clone(), mm)?;
+    let mut ledger = IndexLedger::load(pages.index_registry_page, mm)?;
+    for (address, values) in new_rows {
+        for index in &new_snapshot.indexes {
+            let key: Vec<Value> = index
+                .columns
+                .iter()
+                .map(|col| {
+                    values
+                        .iter()
+                        .find(|(n, _)| n == col)
+                        .map(|(_, v)| v.clone())
+                        .unwrap_or(Value::Null)
+                })
+                .collect();
+            let columns_refs: Vec<&str> = index.columns.iter().map(String::as_str).collect();
+            ledger.insert(&columns_refs, key, *address, mm)?;
+        }
+    }
     Ok(())
 }
 
@@ -249,6 +705,74 @@ where
 
 fn persist_pending_snapshot(pending: &mut Vec<TableSchemaSnapshot>, snapshot: TableSchemaSnapshot) {
     pending.push(snapshot);
+}
+
+fn table_registry_pages<M, A>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+) -> DbmsResult<wasm_dbms_memory::prelude::TableRegistryPage>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    let sr = db.ctx.schema_registry.borrow();
+    sr.table_registry_page_by_name(table).ok_or_else(|| {
+        DbmsError::Migration(MigrationError::ConstraintViolation {
+            table: table.to_string(),
+            column: String::new(),
+            reason: "table not present in schema registry".to_string(),
+        })
+    })
+}
+
+fn load_raw_rows<M, A>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+    snapshot: &TableSchemaSnapshot,
+) -> DbmsResult<Vec<wasm_dbms_memory::RawRecordBytes>>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    let pages = table_registry_pages(db, table)?;
+    let mut mm = db.ctx.mm.borrow_mut();
+    let registry = TableRegistry::load(pages, &mut *mm)?;
+    let mut reader = registry.iter_raw(snapshot.alignment as u16, &mut *mm);
+    let mut rows = Vec::new();
+    while let Some(row) = reader.try_next()? {
+        rows.push(row);
+    }
+    Ok(rows)
+}
+
+type LoadedLiveRow = (wasm_dbms_memory::RecordAddress, Vec<(String, Value)>);
+
+fn load_live_rows<M, A>(
+    db: &WasmDbmsDatabase<'_, M, A>,
+    table: &str,
+    snapshot: &TableSchemaSnapshot,
+) -> DbmsResult<Vec<LoadedLiveRow>>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    load_raw_rows(db, table, snapshot)?
+        .into_iter()
+        .map(|row| {
+            Ok((
+                row.address,
+                decode_record_by_snapshot(&row.bytes, snapshot)?,
+            ))
+        })
+        .collect()
+}
+
+fn count_rows<M, A>(db: &WasmDbmsDatabase<'_, M, A>, table: &str) -> DbmsResult<usize>
+where
+    M: MemoryProvider,
+    A: AccessControl,
+{
+    Ok(db.schema.select(db, table, Query::builder().build())?.len())
 }
 
 fn validate_no_nulls<M, A>(
@@ -352,6 +876,7 @@ mod tests {
 
     use super::*;
     use crate::context::DbmsContext;
+    use crate::database::migration::plan::order_ops;
 
     #[derive(Debug, Table, Clone, PartialEq, Eq)]
     #[table = "users"]
@@ -462,6 +987,62 @@ mod tests {
     }
 
     #[test]
+    fn test_add_index_backfills_rows_after_planner_ordered_column_rewrite() {
+        let ctx = fresh_db();
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            insert_user(&db, 1, "alice");
+            insert_user(&db, 2, "bob");
+        }
+
+        let mut ops = vec![
+            MigrationOp::AddIndex {
+                table: "users".to_string(),
+                index: IndexSnapshot {
+                    columns: vec!["email".to_string()],
+                    unique: false,
+                },
+            },
+            MigrationOp::AddColumn {
+                table: "users".to_string(),
+                column: ColumnSnapshot {
+                    name: "email".to_string(),
+                    data_type: DataTypeSnapshot::Text,
+                    nullable: false,
+                    auto_increment: false,
+                    unique: false,
+                    primary_key: false,
+                    foreign_key: None,
+                    default: Some(Value::Text(Text("guest@example.com".into()))),
+                },
+            },
+        ];
+        order_ops(&mut ops);
+
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            apply(&db, ops).unwrap();
+        }
+
+        let pages = ctx
+            .schema_registry
+            .borrow()
+            .table_registry_page_by_name("users")
+            .unwrap();
+        let mut mm = ctx.mm.borrow_mut();
+        let registry = TableRegistry::load(pages, &mut *mm).unwrap();
+        let hits = registry
+            .index_ledger()
+            .search(
+                &["email"],
+                &vec![Value::Text(Text("guest@example.com".into()))],
+                &mut *mm,
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
     fn test_alter_column_relax_persists_nullability_change() {
         let ctx = fresh_db();
         let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
@@ -489,30 +1070,797 @@ mod tests {
         assert!(name_col.nullable);
     }
 
-    #[test]
-    fn test_data_rewrite_op_returns_unsupported_error() {
-        let ctx = fresh_db();
-        let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+    /// Insert a `User` row through the live `Database` API and return its
+    /// id. Used to seed v1 records before applying a column-mutating
+    /// migration in tests below.
+    fn insert_user(db: &WasmDbmsDatabase<'_, HeapMemoryProvider>, id: u32, name: &str) {
+        use wasm_dbms_api::prelude::Database;
+        db.insert::<User>(UserInsertRequest {
+            id: Uint32(id),
+            name: Text(name.to_string()),
+        })
+        .unwrap();
+    }
 
+    /// Read the stored snapshot for `name`.
+    fn stored_snapshot(ctx: &DbmsContext<HeapMemoryProvider>, name: &str) -> TableSchemaSnapshot {
+        ctx.schema_registry
+            .borrow()
+            .stored_snapshots(&mut *ctx.mm.borrow_mut())
+            .unwrap()
+            .into_iter()
+            .find(|s| s.name == name)
+            .expect("stored snapshot not found")
+    }
+
+    /// Read every record under `snapshot` via the snapshot codec.
+    fn read_rows_under(
+        ctx: &DbmsContext<HeapMemoryProvider>,
+        snapshot: &TableSchemaSnapshot,
+    ) -> Vec<Vec<(String, Value)>> {
+        use crate::database::migration::codec::decode_record_by_snapshot;
+        let pages = ctx
+            .schema_registry
+            .borrow()
+            .table_registry_page_by_name(&snapshot.name)
+            .expect("table not found");
+        let mut mm = ctx.mm.borrow_mut();
+        let registry = TableRegistry::load(pages, &mut *mm).unwrap();
+        let mut reader = registry.iter_raw(snapshot.alignment as u16, &mut *mm);
+        let mut rows = Vec::new();
+        while let Some(row) = reader.try_next().unwrap() {
+            rows.push(decode_record_by_snapshot(&row.bytes, snapshot).unwrap());
+        }
+        rows
+    }
+
+    #[test]
+    fn test_add_column_nullable_backfills_null() {
+        let ctx = fresh_db();
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            insert_user(&db, 1, "alice");
+        }
+
+        let new_col = ColumnSnapshot {
+            name: "email".to_string(),
+            data_type: DataTypeSnapshot::Text,
+            nullable: true,
+            auto_increment: false,
+            unique: false,
+            primary_key: false,
+            foreign_key: None,
+            default: None,
+        };
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            apply(
+                &db,
+                vec![MigrationOp::AddColumn {
+                    table: "users".to_string(),
+                    column: new_col.clone(),
+                }],
+            )
+            .unwrap();
+        }
+
+        let snap = stored_snapshot(&ctx, "users");
+        let rows = read_rows_under(&ctx, &snap);
+        assert_eq!(rows.len(), 1);
+        let email = rows[0]
+            .iter()
+            .find(|(n, _)| n == "email")
+            .map(|(_, v)| v)
+            .unwrap();
+        assert_eq!(email, &Value::Null);
+    }
+
+    #[test]
+    fn test_add_column_with_default_attribute_backfills_value() {
+        let ctx = fresh_db();
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            insert_user(&db, 1, "alice");
+        }
+
+        let default_value = Value::Text(Text("guest@example.com".into()));
+        let new_col = ColumnSnapshot {
+            name: "email".to_string(),
+            data_type: DataTypeSnapshot::Text,
+            nullable: false,
+            auto_increment: false,
+            unique: false,
+            primary_key: false,
+            foreign_key: None,
+            default: Some(default_value.clone()),
+        };
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            apply(
+                &db,
+                vec![MigrationOp::AddColumn {
+                    table: "users".to_string(),
+                    column: new_col.clone(),
+                }],
+            )
+            .unwrap();
+        }
+
+        let snap = stored_snapshot(&ctx, "users");
+        let rows = read_rows_under(&ctx, &snap);
+        assert_eq!(rows.len(), 1);
+        let email = rows[0]
+            .iter()
+            .find(|(n, _)| n == "email")
+            .map(|(_, v)| v)
+            .unwrap();
+        assert_eq!(email, &default_value);
+    }
+
+    #[test]
+    fn test_add_column_non_null_no_default_returns_default_missing() {
+        let ctx = fresh_db();
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            insert_user(&db, 1, "alice");
+        }
+
+        let bad_col = ColumnSnapshot {
+            name: "email".to_string(),
+            data_type: DataTypeSnapshot::Text,
+            nullable: false,
+            auto_increment: false,
+            unique: false,
+            primary_key: false,
+            foreign_key: None,
+            default: None,
+        };
+        let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
         let result = apply(
             &db,
             vec![MigrationOp::AddColumn {
                 table: "users".to_string(),
-                column: ColumnSnapshot {
-                    name: "email".to_string(),
-                    data_type: DataTypeSnapshot::Text,
-                    nullable: true,
-                    auto_increment: false,
-                    unique: false,
-                    primary_key: false,
-                    foreign_key: None,
-                    default: None,
+                column: bad_col,
+            }],
+        );
+        assert!(matches!(
+            result,
+            Err(DbmsError::Migration(MigrationError::DefaultMissing { .. }))
+        ));
+    }
+
+    #[test]
+    fn test_add_column_unique_default_is_rejected_and_rolled_back() {
+        let ctx = fresh_db();
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            insert_user(&db, 1, "alice");
+            insert_user(&db, 2, "bob");
+        }
+
+        let result = {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            apply(
+                &db,
+                vec![MigrationOp::AddColumn {
+                    table: "users".to_string(),
+                    column: ColumnSnapshot {
+                        name: "email".to_string(),
+                        data_type: DataTypeSnapshot::Text,
+                        nullable: false,
+                        auto_increment: false,
+                        unique: true,
+                        primary_key: false,
+                        foreign_key: None,
+                        default: Some(Value::Text(Text("same@example.com".into()))),
+                    },
+                }],
+            )
+        };
+        assert!(matches!(
+            result,
+            Err(DbmsError::Migration(
+                MigrationError::ConstraintViolation { .. }
+            ))
+        ));
+
+        let snap = stored_snapshot(&ctx, "users");
+        assert!(!snap.columns.iter().any(|c| c.name == "email"));
+        let rows = read_rows_under(&ctx, &snap);
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn test_drop_column_removes_value_from_existing_records() {
+        let ctx = fresh_db();
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            insert_user(&db, 1, "alice");
+        }
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            apply(
+                &db,
+                vec![MigrationOp::DropColumn {
+                    table: "users".to_string(),
+                    column: "name".to_string(),
+                }],
+            )
+            .unwrap();
+        }
+
+        let snap = stored_snapshot(&ctx, "users");
+        assert!(!snap.columns.iter().any(|c| c.name == "name"));
+        let rows = read_rows_under(&ctx, &snap);
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].iter().all(|(n, _)| n != "name"));
+        let id = rows[0]
+            .iter()
+            .find(|(n, _)| n == "id")
+            .map(|(_, v)| v)
+            .unwrap();
+        assert_eq!(id, &Value::Uint32(Uint32(1)));
+    }
+
+    #[test]
+    fn test_rename_column_preserves_data_under_new_name() {
+        let ctx = fresh_db();
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            insert_user(&db, 1, "alice");
+        }
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            apply(
+                &db,
+                vec![MigrationOp::RenameColumn {
+                    table: "users".to_string(),
+                    old: "name".to_string(),
+                    new: "username".to_string(),
+                }],
+            )
+            .unwrap();
+        }
+
+        let snap = stored_snapshot(&ctx, "users");
+        assert!(snap.columns.iter().any(|c| c.name == "username"));
+        assert!(!snap.columns.iter().any(|c| c.name == "name"));
+        let rows = read_rows_under(&ctx, &snap);
+        assert_eq!(rows.len(), 1);
+        let username = rows[0]
+            .iter()
+            .find(|(n, _)| n == "username")
+            .map(|(_, v)| v)
+            .unwrap();
+        assert_eq!(username, &Value::Text(Text("alice".into())));
+    }
+
+    #[test]
+    fn test_widen_column_uint32_to_uint64_preserves_values() {
+        let ctx = fresh_db();
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            insert_user(&db, 7, "alice");
+        }
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            apply(
+                &db,
+                vec![MigrationOp::WidenColumn {
+                    table: "users".to_string(),
+                    column: "id".to_string(),
+                    old_type: DataTypeSnapshot::Uint32,
+                    new_type: DataTypeSnapshot::Uint64,
+                }],
+            )
+            .unwrap();
+        }
+
+        let snap = stored_snapshot(&ctx, "users");
+        let id_col = snap.columns.iter().find(|c| c.name == "id").unwrap();
+        assert_eq!(id_col.data_type, DataTypeSnapshot::Uint64);
+        let rows = read_rows_under(&ctx, &snap);
+        assert_eq!(rows.len(), 1);
+        let id = rows[0]
+            .iter()
+            .find(|(n, _)| n == "id")
+            .map(|(_, v)| v)
+            .unwrap();
+        assert_eq!(id, &Value::Uint64(wasm_dbms_api::prelude::Uint64(7)));
+    }
+
+    #[test]
+    fn test_widen_column_incompatible_returns_widening_incompatible() {
+        let ctx = fresh_db();
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            insert_user(&db, 7, "alice");
+        }
+        let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+        let result = apply(
+            &db,
+            vec![MigrationOp::WidenColumn {
+                table: "users".to_string(),
+                column: "id".to_string(),
+                old_type: DataTypeSnapshot::Uint32,
+                new_type: DataTypeSnapshot::Uint8,
+            }],
+        );
+        assert!(matches!(
+            result,
+            Err(DbmsError::Migration(
+                MigrationError::WideningIncompatible { .. }
+            ))
+        ));
+    }
+
+    /// Schema fixture with a custom `Migrate::transform_column` impl that
+    /// converts `Uint32` ids into prefixed `Text` "user-N" values.
+    mod transform_fixture {
+        use wasm_dbms_api::prelude::Migrate;
+
+        use super::*;
+
+        #[derive(Debug, Table, Clone, PartialEq, Eq)]
+        #[table = "users"]
+        #[migrate]
+        pub struct User {
+            #[primary_key]
+            pub id: Uint32,
+            pub name: Text,
+        }
+
+        impl Migrate for User {
+            fn transform_column(column: &str, old: Value) -> DbmsResult<Option<Value>> {
+                if column == "id"
+                    && let Value::Uint32(Uint32(n)) = old
+                {
+                    return Ok(Some(Value::Text(Text(format!("user-{n}")))));
+                }
+                Ok(None)
+            }
+        }
+
+        #[derive(DatabaseSchema)]
+        #[tables(User = "users")]
+        pub struct UserSchema;
+    }
+
+    #[test]
+    fn test_transform_column_invokes_migrate_transform_per_row() {
+        let ctx = DbmsContext::new(HeapMemoryProvider::default());
+        transform_fixture::UserSchema::register_tables(&ctx).unwrap();
+        {
+            use transform_fixture::User as TUser;
+            let db = WasmDbmsDatabase::oneshot(&ctx, transform_fixture::UserSchema);
+            use wasm_dbms_api::prelude::Database;
+            db.insert::<TUser>(transform_fixture::UserInsertRequest {
+                id: Uint32(7),
+                name: Text("alice".into()),
+            })
+            .unwrap();
+        }
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, transform_fixture::UserSchema);
+            apply(
+                &db,
+                vec![MigrationOp::TransformColumn {
+                    table: "users".to_string(),
+                    column: "id".to_string(),
+                    old_type: DataTypeSnapshot::Uint32,
+                    new_type: DataTypeSnapshot::Text,
+                }],
+            )
+            .unwrap();
+        }
+
+        let snap = stored_snapshot(&ctx, "users");
+        let id_col = snap.columns.iter().find(|c| c.name == "id").unwrap();
+        assert_eq!(id_col.data_type, DataTypeSnapshot::Text);
+        let rows = read_rows_under(&ctx, &snap);
+        assert_eq!(rows.len(), 1);
+        let id = rows[0]
+            .iter()
+            .find(|(n, _)| n == "id")
+            .map(|(_, v)| v)
+            .unwrap();
+        assert_eq!(id, &Value::Text(Text("user-7".into())));
+    }
+
+    /// Two-table schema (users + posts) for FK-related tests.
+    mod fk_fixture {
+        use super::*;
+
+        #[derive(Debug, Table, Clone, PartialEq, Eq)]
+        #[table = "users"]
+        pub struct User {
+            #[primary_key]
+            pub id: Uint32,
+            pub name: Text,
+        }
+
+        #[derive(Debug, Table, Clone, PartialEq, Eq)]
+        #[table = "posts"]
+        pub struct Post {
+            #[primary_key]
+            pub id: Uint32,
+            pub owner: Uint32,
+            pub title: Text,
+        }
+
+        #[derive(DatabaseSchema)]
+        #[tables(User = "users", Post = "posts")]
+        pub struct Schema;
+    }
+
+    #[test]
+    fn test_add_column_fk_invalid_default_is_rejected_and_rolled_back() {
+        use wasm_dbms_api::prelude::{Database, ForeignKeySnapshot, OnDeleteSnapshot};
+
+        let ctx = DbmsContext::new(HeapMemoryProvider::default());
+        fk_fixture::Schema::register_tables(&ctx).unwrap();
+
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, fk_fixture::Schema);
+            db.insert::<fk_fixture::User>(fk_fixture::UserInsertRequest {
+                id: Uint32(1),
+                name: Text("alice".into()),
+            })
+            .unwrap();
+            db.insert::<fk_fixture::Post>(fk_fixture::PostInsertRequest {
+                id: Uint32(10),
+                owner: Uint32(1),
+                title: Text("x".into()),
+            })
+            .unwrap();
+        }
+
+        let result = {
+            let db = WasmDbmsDatabase::oneshot(&ctx, fk_fixture::Schema);
+            apply(
+                &db,
+                vec![MigrationOp::AddColumn {
+                    table: "posts".to_string(),
+                    column: ColumnSnapshot {
+                        name: "reviewer".to_string(),
+                        data_type: DataTypeSnapshot::Uint32,
+                        nullable: false,
+                        auto_increment: false,
+                        unique: false,
+                        primary_key: false,
+                        foreign_key: Some(ForeignKeySnapshot {
+                            table: "users".to_string(),
+                            column: "id".to_string(),
+                            on_delete: OnDeleteSnapshot::Restrict,
+                        }),
+                        default: Some(Value::Uint32(Uint32(99))),
+                    },
+                }],
+            )
+        };
+        assert!(matches!(
+            result,
+            Err(DbmsError::Migration(
+                MigrationError::ForeignKeyViolation { .. }
+            ))
+        ));
+
+        let snap = stored_snapshot(&ctx, "posts");
+        assert!(!snap.columns.iter().any(|c| c.name == "reviewer"));
+        let rows = read_rows_under(&ctx, &snap);
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn test_multi_op_apply_is_atomic() {
+        // Apply an AddColumn + RenameColumn + WidenColumn sequence in one
+        // call and verify the final state is consistent across all three
+        // ops.
+        let ctx = fresh_db();
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            insert_user(&db, 7, "alice");
+        }
+
+        let new_email = ColumnSnapshot {
+            name: "email".to_string(),
+            data_type: DataTypeSnapshot::Text,
+            nullable: false,
+            auto_increment: false,
+            unique: false,
+            primary_key: false,
+            foreign_key: None,
+            default: Some(Value::Text(Text("missing@example.com".into()))),
+        };
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            apply(
+                &db,
+                vec![
+                    MigrationOp::AddColumn {
+                        table: "users".to_string(),
+                        column: new_email.clone(),
+                    },
+                    MigrationOp::RenameColumn {
+                        table: "users".to_string(),
+                        old: "name".to_string(),
+                        new: "username".to_string(),
+                    },
+                    MigrationOp::WidenColumn {
+                        table: "users".to_string(),
+                        column: "id".to_string(),
+                        old_type: DataTypeSnapshot::Uint32,
+                        new_type: DataTypeSnapshot::Uint64,
+                    },
+                ],
+            )
+            .unwrap();
+        }
+
+        let snap = stored_snapshot(&ctx, "users");
+        assert!(snap.columns.iter().any(|c| c.name == "email"));
+        assert!(snap.columns.iter().any(|c| c.name == "username"));
+        assert!(!snap.columns.iter().any(|c| c.name == "name"));
+        assert_eq!(
+            snap.columns
+                .iter()
+                .find(|c| c.name == "id")
+                .unwrap()
+                .data_type,
+            DataTypeSnapshot::Uint64
+        );
+
+        let rows = read_rows_under(&ctx, &snap);
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        let id = row.iter().find(|(n, _)| n == "id").unwrap();
+        assert_eq!(id.1, Value::Uint64(wasm_dbms_api::prelude::Uint64(7)));
+        let username = row.iter().find(|(n, _)| n == "username").unwrap();
+        assert_eq!(username.1, Value::Text(Text("alice".into())));
+        let email = row.iter().find(|(n, _)| n == "email").unwrap();
+        assert_eq!(email.1, Value::Text(Text("missing@example.com".into())));
+    }
+
+    #[test]
+    fn test_widen_incompatible_rolls_back_data_rewrite() {
+        let ctx = fresh_db();
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            insert_user(&db, 7, "alice");
+        }
+
+        // Sequence: a valid AddColumn, then an invalid WidenColumn that
+        // must abort the apply pass and roll back the AddColumn rewrite.
+        let bad_widen = MigrationOp::WidenColumn {
+            table: "users".to_string(),
+            column: "id".to_string(),
+            old_type: DataTypeSnapshot::Uint32,
+            new_type: DataTypeSnapshot::Uint8,
+        };
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            let result = apply(
+                &db,
+                vec![
+                    MigrationOp::AddColumn {
+                        table: "users".to_string(),
+                        column: ColumnSnapshot {
+                            name: "email".to_string(),
+                            data_type: DataTypeSnapshot::Text,
+                            nullable: true,
+                            auto_increment: false,
+                            unique: false,
+                            primary_key: false,
+                            foreign_key: None,
+                            default: None,
+                        },
+                    },
+                    bad_widen,
+                ],
+            );
+            assert!(matches!(
+                result,
+                Err(DbmsError::Migration(
+                    MigrationError::WideningIncompatible { .. }
+                ))
+            ));
+        }
+
+        // Snapshot must be unchanged: still {id, name}.
+        let snap = stored_snapshot(&ctx, "users");
+        assert!(!snap.columns.iter().any(|c| c.name == "email"));
+        assert!(snap.columns.iter().any(|c| c.name == "name"));
+        assert_eq!(
+            snap.columns
+                .iter()
+                .find(|c| c.name == "id")
+                .unwrap()
+                .data_type,
+            DataTypeSnapshot::Uint32
+        );
+        let rows = read_rows_under(&ctx, &snap);
+        assert_eq!(rows.len(), 1);
+        let id = rows[0].iter().find(|(n, _)| n == "id").unwrap();
+        assert_eq!(id.1, Value::Uint32(Uint32(7)));
+    }
+
+    #[test]
+    fn test_indexes_rebuilt_after_column_rewrite() {
+        // Schema with a secondary index on `name`.
+        #[derive(Debug, Table, Clone, PartialEq, Eq)]
+        #[table = "users"]
+        pub struct IndexedUser {
+            #[primary_key]
+            pub id: Uint32,
+            #[index]
+            pub name: Text,
+        }
+
+        #[derive(DatabaseSchema)]
+        #[tables(IndexedUser = "users")]
+        pub struct Schema;
+
+        use wasm_dbms_api::prelude::Database;
+
+        let ctx = DbmsContext::new(HeapMemoryProvider::default());
+        Schema::register_tables(&ctx).unwrap();
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, Schema);
+            db.insert::<IndexedUser>(IndexedUserInsertRequest {
+                id: Uint32(1),
+                name: Text("alice".into()),
+            })
+            .unwrap();
+        }
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, Schema);
+            apply(
+                &db,
+                vec![MigrationOp::AddColumn {
+                    table: "users".to_string(),
+                    column: ColumnSnapshot {
+                        name: "email".to_string(),
+                        data_type: DataTypeSnapshot::Text,
+                        nullable: true,
+                        auto_increment: false,
+                        unique: false,
+                        primary_key: false,
+                        foreign_key: None,
+                        default: None,
+                    },
+                }],
+            )
+            .unwrap();
+        }
+
+        // Index on `name` should have been rebuilt against the new record
+        // address. Verify by reading via the index ledger.
+        let pages = ctx
+            .schema_registry
+            .borrow()
+            .table_registry_page_by_name("users")
+            .unwrap();
+        let mut mm = ctx.mm.borrow_mut();
+        let registry = TableRegistry::load(pages, &mut *mm).unwrap();
+        let hits = registry
+            .index_ledger()
+            .search(
+                &["name"],
+                &vec![Value::Text(Text("alice".into()))],
+                &mut *mm,
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        // The address must be a real live record — read back via raw reader.
+        let body = registry.read_raw_at(hits[0], &mut *mm).unwrap();
+        assert!(!body.is_empty());
+    }
+
+    #[test]
+    fn test_alter_column_add_fk_with_broken_row_returns_violation() {
+        use wasm_dbms_api::prelude::{Database, ForeignKeySnapshot, OnDeleteSnapshot};
+
+        let ctx = DbmsContext::new(HeapMemoryProvider::default());
+        fk_fixture::Schema::register_tables(&ctx).unwrap();
+
+        let db = WasmDbmsDatabase::oneshot(&ctx, fk_fixture::Schema);
+        // No users inserted. Insert a post pointing at a non-existent user.
+        db.insert::<fk_fixture::User>(fk_fixture::UserInsertRequest {
+            id: Uint32(1),
+            name: Text("alice".into()),
+        })
+        .unwrap();
+        db.insert::<fk_fixture::Post>(fk_fixture::PostInsertRequest {
+            id: Uint32(10),
+            owner: Uint32(99),
+            title: Text("x".into()),
+        })
+        .unwrap();
+
+        let result = apply(
+            &db,
+            vec![MigrationOp::AlterColumn {
+                table: "posts".to_string(),
+                column: "owner".to_string(),
+                changes: ColumnChanges {
+                    foreign_key: Some(Some(ForeignKeySnapshot {
+                        table: "users".to_string(),
+                        column: "id".to_string(),
+                        on_delete: OnDeleteSnapshot::Restrict,
+                    })),
+                    ..Default::default()
                 },
             }],
         );
         assert!(matches!(
             result,
-            Err(DbmsError::Migration(MigrationError::DataRewriteUnsupported { ref op })) if op == "AddColumn"
+            Err(DbmsError::Migration(
+                MigrationError::ForeignKeyViolation { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_alter_column_add_fk_with_valid_rows_succeeds() {
+        use wasm_dbms_api::prelude::{Database, ForeignKeySnapshot, OnDeleteSnapshot};
+
+        let ctx = DbmsContext::new(HeapMemoryProvider::default());
+        fk_fixture::Schema::register_tables(&ctx).unwrap();
+
+        let db = WasmDbmsDatabase::oneshot(&ctx, fk_fixture::Schema);
+        db.insert::<fk_fixture::User>(fk_fixture::UserInsertRequest {
+            id: Uint32(1),
+            name: Text("alice".into()),
+        })
+        .unwrap();
+        db.insert::<fk_fixture::Post>(fk_fixture::PostInsertRequest {
+            id: Uint32(10),
+            owner: Uint32(1),
+            title: Text("x".into()),
+        })
+        .unwrap();
+
+        apply(
+            &db,
+            vec![MigrationOp::AlterColumn {
+                table: "posts".to_string(),
+                column: "owner".to_string(),
+                changes: ColumnChanges {
+                    foreign_key: Some(Some(ForeignKeySnapshot {
+                        table: "users".to_string(),
+                        column: "id".to_string(),
+                        on_delete: OnDeleteSnapshot::Restrict,
+                    })),
+                    ..Default::default()
+                },
+            }],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_transform_column_returning_none_errors() {
+        // Default UserSchema's Migrate impl returns Ok(None) — should fail.
+        let ctx = fresh_db();
+        {
+            let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+            insert_user(&db, 7, "alice");
+        }
+        let db = WasmDbmsDatabase::oneshot(&ctx, UserSchema);
+        let result = apply(
+            &db,
+            vec![MigrationOp::TransformColumn {
+                table: "users".to_string(),
+                column: "id".to_string(),
+                old_type: DataTypeSnapshot::Uint32,
+                new_type: DataTypeSnapshot::Text,
+            }],
+        );
+        assert!(matches!(
+            result,
+            Err(DbmsError::Migration(
+                MigrationError::TransformReturnedNone { .. }
+            ))
         ));
     }
 

--- a/crates/wasm-dbms/wasm-dbms/src/database/migration/codec.rs
+++ b/crates/wasm-dbms/wasm-dbms/src/database/migration/codec.rs
@@ -1,0 +1,408 @@
+// Rust guideline compliant 2026-04-27
+
+//! Snapshot-driven record (de)serializer.
+//!
+//! Walks a [`TableSchemaSnapshot`] column list and dispatches per
+//! [`DataTypeSnapshot`] variant to slice raw record bytes into typed
+//! [`Value`]s — independent of the compile-time `T: TableSchema` type.
+//!
+//! Used by the migration apply pipeline to read records under the **stored**
+//! snapshot and re-encode them under a target snapshot. Custom-typed columns
+//! produce [`CustomValue`] with an empty `display`; consumers
+//! (`Migrate::transform_column`, the symmetric encode) only depend on
+//! `type_tag` + `encoded` and never read `display`.
+
+use wasm_dbms_api::prelude::{
+    Blob, Boolean, CustomValue, DataTypeSnapshot, Date, DateTime, Decimal, DecodeError, Encode,
+    Int8, Int16, Int32, Int64, Json, MemoryError, MemoryResult, TableSchemaSnapshot, Text, Uint8,
+    Uint16, Uint32, Uint64, Uuid, Value, WireSize,
+};
+
+/// Decode raw record bytes under the given stored snapshot into a
+/// column-keyed value list.
+///
+/// # Errors
+///
+/// Returns [`MemoryError::DecodeError`] on truncated or shape-mismatched
+/// bytes (`TooShort`, `IdentityDecodeError` for unsupported variants).
+pub(crate) fn decode_record_by_snapshot(
+    bytes: &[u8],
+    snapshot: &TableSchemaSnapshot,
+) -> MemoryResult<Vec<(String, Value)>> {
+    let mut offset = 0usize;
+    let mut out = Vec::with_capacity(snapshot.columns.len());
+    for col in &snapshot.columns {
+        if offset > bytes.len() {
+            return Err(MemoryError::DecodeError(DecodeError::TooShort));
+        }
+        let (value, consumed) = decode_column(&col.data_type, col.nullable, &bytes[offset..])?;
+        out.push((col.name.clone(), value));
+        offset += consumed;
+    }
+    Ok(out)
+}
+
+/// Encode `values` as raw record bytes under the target snapshot.
+///
+/// `values` must match `snapshot.columns` in length and order; the caller
+/// (typically the migration apply pipeline) is responsible for projecting
+/// the row before invoking this.
+///
+/// # Errors
+///
+/// Returns [`MemoryError::DecodeError(IdentityDecodeError)`] on shape
+/// mismatch or `Value`/`DataTypeSnapshot` discriminant mismatch.
+pub(crate) fn encode_record_by_snapshot(
+    values: &[(String, Value)],
+    snapshot: &TableSchemaSnapshot,
+) -> MemoryResult<Vec<u8>> {
+    if values.len() != snapshot.columns.len() {
+        return Err(MemoryError::DecodeError(DecodeError::IdentityDecodeError(
+            format!(
+                "value count ({}) does not match column count ({})",
+                values.len(),
+                snapshot.columns.len(),
+            ),
+        )));
+    }
+    let mut out = Vec::new();
+    for (col, (name, value)) in snapshot.columns.iter().zip(values.iter()) {
+        if &col.name != name {
+            return Err(MemoryError::DecodeError(DecodeError::IdentityDecodeError(
+                format!("value name `{}` does not match column `{}`", name, col.name,),
+            )));
+        }
+        encode_column(&col.data_type, col.nullable, value, &mut out)?;
+    }
+    Ok(out)
+}
+
+fn decode_column(
+    dt: &DataTypeSnapshot,
+    nullable: bool,
+    bytes: &[u8],
+) -> MemoryResult<(Value, usize)> {
+    if nullable {
+        if bytes.is_empty() {
+            return Err(MemoryError::DecodeError(DecodeError::TooShort));
+        }
+        match bytes[0] {
+            0 => Ok((Value::Null, 1)),
+            1 => {
+                let (value, consumed) = decode_non_nullable(dt, &bytes[1..])?;
+                Ok((value, 1 + consumed))
+            }
+            v => Err(MemoryError::DecodeError(DecodeError::IdentityDecodeError(
+                format!("Invalid nullable flag: {v:#x}"),
+            ))),
+        }
+    } else {
+        decode_non_nullable(dt, bytes)
+    }
+}
+
+fn decode_non_nullable(dt: &DataTypeSnapshot, bytes: &[u8]) -> MemoryResult<(Value, usize)> {
+    match dt {
+        DataTypeSnapshot::Int8 => decode_fixed::<Int8>(bytes, 1).map(|(v, n)| (Value::Int8(v), n)),
+        DataTypeSnapshot::Uint8 => {
+            decode_fixed::<Uint8>(bytes, 1).map(|(v, n)| (Value::Uint8(v), n))
+        }
+        DataTypeSnapshot::Boolean => {
+            decode_fixed::<Boolean>(bytes, 1).map(|(v, n)| (Value::Boolean(v), n))
+        }
+        DataTypeSnapshot::Int16 => {
+            decode_fixed::<Int16>(bytes, 2).map(|(v, n)| (Value::Int16(v), n))
+        }
+        DataTypeSnapshot::Uint16 => {
+            decode_fixed::<Uint16>(bytes, 2).map(|(v, n)| (Value::Uint16(v), n))
+        }
+        DataTypeSnapshot::Int32 => {
+            decode_fixed::<Int32>(bytes, 4).map(|(v, n)| (Value::Int32(v), n))
+        }
+        DataTypeSnapshot::Uint32 => {
+            decode_fixed::<Uint32>(bytes, 4).map(|(v, n)| (Value::Uint32(v), n))
+        }
+        DataTypeSnapshot::Date => decode_fixed::<Date>(bytes, 4).map(|(v, n)| (Value::Date(v), n)),
+        DataTypeSnapshot::Int64 => {
+            decode_fixed::<Int64>(bytes, 8).map(|(v, n)| (Value::Int64(v), n))
+        }
+        DataTypeSnapshot::Uint64 => {
+            decode_fixed::<Uint64>(bytes, 8).map(|(v, n)| (Value::Uint64(v), n))
+        }
+        DataTypeSnapshot::Datetime => {
+            decode_fixed::<DateTime>(bytes, 13).map(|(v, n)| (Value::DateTime(v), n))
+        }
+        DataTypeSnapshot::Decimal => {
+            decode_fixed::<Decimal>(bytes, 16).map(|(v, n)| (Value::Decimal(v), n))
+        }
+        DataTypeSnapshot::Uuid => decode_fixed::<Uuid>(bytes, 16).map(|(v, n)| (Value::Uuid(v), n)),
+        DataTypeSnapshot::Text => {
+            decode_length_prefixed::<Text>(bytes).map(|(v, n)| (Value::Text(v), n))
+        }
+        DataTypeSnapshot::Blob => {
+            decode_length_prefixed::<Blob>(bytes).map(|(v, n)| (Value::Blob(v), n))
+        }
+        DataTypeSnapshot::Json => {
+            decode_length_prefixed::<Json>(bytes).map(|(v, n)| (Value::Json(v), n))
+        }
+        DataTypeSnapshot::Custom(meta) => {
+            let (slice, consumed) = match meta.wire_size {
+                WireSize::Fixed(n) => {
+                    let n = n as usize;
+                    if bytes.len() < n {
+                        return Err(MemoryError::DecodeError(DecodeError::TooShort));
+                    }
+                    (bytes[..n].to_vec(), n)
+                }
+                WireSize::LengthPrefixed => {
+                    if bytes.len() < 2 {
+                        return Err(MemoryError::DecodeError(DecodeError::TooShort));
+                    }
+                    let len = u16::from_le_bytes([bytes[0], bytes[1]]) as usize;
+                    let total = 2 + len;
+                    if bytes.len() < total {
+                        return Err(MemoryError::DecodeError(DecodeError::TooShort));
+                    }
+                    (bytes[..total].to_vec(), total)
+                }
+            };
+            let value = Value::Custom(CustomValue {
+                type_tag: meta.tag.clone(),
+                encoded: slice,
+                display: String::new(),
+            });
+            Ok((value, consumed))
+        }
+        // `Float32`/`Float64` exist in `DataTypeSnapshot` but no compile-time
+        // `Value::FloatXX` variants, so a compiled schema cannot produce them.
+        // If a stored snapshot somehow carries one, fail loud rather than
+        // silently misdecoding bytes.
+        DataTypeSnapshot::Float32 | DataTypeSnapshot::Float64 => {
+            Err(MemoryError::DecodeError(DecodeError::IdentityDecodeError(
+                format!("Float types are not yet wired into the snapshot codec: {dt:?}"),
+            )))
+        }
+    }
+}
+
+fn decode_fixed<T>(bytes: &[u8], size: usize) -> MemoryResult<(T, usize)>
+where
+    T: Encode,
+{
+    if bytes.len() < size {
+        return Err(MemoryError::DecodeError(DecodeError::TooShort));
+    }
+    let value = T::decode(std::borrow::Cow::Borrowed(&bytes[..size]))?;
+    Ok((value, size))
+}
+
+fn decode_length_prefixed<T>(bytes: &[u8]) -> MemoryResult<(T, usize)>
+where
+    T: Encode,
+{
+    if bytes.len() < 2 {
+        return Err(MemoryError::DecodeError(DecodeError::TooShort));
+    }
+    let len = u16::from_le_bytes([bytes[0], bytes[1]]) as usize;
+    let total = 2 + len;
+    if bytes.len() < total {
+        return Err(MemoryError::DecodeError(DecodeError::TooShort));
+    }
+    let value = T::decode(std::borrow::Cow::Borrowed(&bytes[..total]))?;
+    Ok((value, total))
+}
+
+fn encode_column(
+    dt: &DataTypeSnapshot,
+    nullable: bool,
+    value: &Value,
+    out: &mut Vec<u8>,
+) -> MemoryResult<()> {
+    if nullable {
+        match value {
+            Value::Null => {
+                out.push(0);
+                return Ok(());
+            }
+            _ => out.push(1),
+        }
+    } else if matches!(value, Value::Null) {
+        return Err(MemoryError::DecodeError(DecodeError::IdentityDecodeError(
+            "Value::Null in non-nullable column".to_string(),
+        )));
+    }
+    encode_non_nullable(dt, value, out)
+}
+
+fn encode_non_nullable(
+    dt: &DataTypeSnapshot,
+    value: &Value,
+    out: &mut Vec<u8>,
+) -> MemoryResult<()> {
+    match (dt, value) {
+        (DataTypeSnapshot::Int8, Value::Int8(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Uint8, Value::Uint8(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Boolean, Value::Boolean(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Int16, Value::Int16(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Uint16, Value::Uint16(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Int32, Value::Int32(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Uint32, Value::Uint32(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Date, Value::Date(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Int64, Value::Int64(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Uint64, Value::Uint64(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Datetime, Value::DateTime(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Decimal, Value::Decimal(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Uuid, Value::Uuid(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Text, Value::Text(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Blob, Value::Blob(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Json, Value::Json(v)) => out.extend_from_slice(&v.encode()),
+        (DataTypeSnapshot::Custom(_), Value::Custom(cv)) => {
+            out.extend_from_slice(&cv.encoded);
+        }
+        (DataTypeSnapshot::Float32 | DataTypeSnapshot::Float64, _) => {
+            return Err(MemoryError::DecodeError(DecodeError::IdentityDecodeError(
+                format!("Float types are not yet wired into the snapshot codec: {dt:?}"),
+            )));
+        }
+        (dt, value) => {
+            return Err(MemoryError::DecodeError(DecodeError::IdentityDecodeError(
+                format!("Value variant does not match data type: {dt:?} vs {value:?}"),
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use wasm_dbms_api::prelude::{
+        ColumnSnapshot, CustomDataTypeSnapshot, DataTypeSnapshot, Int64, TableSchemaSnapshot, Text,
+        Uint32, Value, WireSize,
+    };
+
+    use super::*;
+
+    fn snap_with(columns: Vec<ColumnSnapshot>) -> TableSchemaSnapshot {
+        TableSchemaSnapshot {
+            version: TableSchemaSnapshot::latest_version(),
+            name: "t".into(),
+            primary_key: "id".into(),
+            alignment: 32,
+            columns,
+            indexes: vec![],
+        }
+    }
+
+    fn col(name: &str, dt: DataTypeSnapshot, nullable: bool) -> ColumnSnapshot {
+        ColumnSnapshot {
+            name: name.into(),
+            data_type: dt,
+            nullable,
+            auto_increment: false,
+            unique: false,
+            primary_key: false,
+            foreign_key: None,
+            default: None,
+        }
+    }
+
+    #[test]
+    fn test_round_trip_uint32_text() {
+        let snap = snap_with(vec![
+            col("id", DataTypeSnapshot::Uint32, false),
+            col("name", DataTypeSnapshot::Text, false),
+        ]);
+        let values: Vec<(String, Value)> = vec![
+            ("id".into(), Value::Uint32(Uint32(7))),
+            ("name".into(), Value::Text(Text("alice".into()))),
+        ];
+        let bytes = encode_record_by_snapshot(&values, &snap).unwrap();
+        let decoded = decode_record_by_snapshot(&bytes, &snap).unwrap();
+        assert_eq!(decoded, values);
+    }
+
+    #[test]
+    fn test_round_trip_nullable_null_and_value() {
+        let snap = snap_with(vec![
+            col("a", DataTypeSnapshot::Int64, true),
+            col("b", DataTypeSnapshot::Int64, true),
+        ]);
+        let values = vec![
+            ("a".into(), Value::Null),
+            ("b".into(), Value::Int64(Int64(-3))),
+        ];
+        let bytes = encode_record_by_snapshot(&values, &snap).unwrap();
+        let decoded = decode_record_by_snapshot(&bytes, &snap).unwrap();
+        assert_eq!(decoded, values);
+    }
+
+    #[test]
+    fn test_round_trip_custom_fixed() {
+        let snap = snap_with(vec![col(
+            "status",
+            DataTypeSnapshot::Custom(Box::new(CustomDataTypeSnapshot {
+                tag: "TestStatus".into(),
+                wire_size: WireSize::Fixed(1),
+            })),
+            false,
+        )]);
+        let values = vec![(
+            "status".into(),
+            Value::Custom(CustomValue {
+                type_tag: "TestStatus".into(),
+                encoded: vec![0x01],
+                display: String::new(),
+            }),
+        )];
+        let bytes = encode_record_by_snapshot(&values, &snap).unwrap();
+        let decoded = decode_record_by_snapshot(&bytes, &snap).unwrap();
+        assert_eq!(decoded, values);
+    }
+
+    #[test]
+    fn test_round_trip_custom_length_prefixed() {
+        let snap = snap_with(vec![col(
+            "blob",
+            DataTypeSnapshot::Custom(Box::new(CustomDataTypeSnapshot {
+                tag: "MyBlob".into(),
+                wire_size: WireSize::LengthPrefixed,
+            })),
+            false,
+        )]);
+        // user encoder convention: 2-byte LE prefix + body.
+        let body = b"hello";
+        let mut encoded = (body.len() as u16).to_le_bytes().to_vec();
+        encoded.extend_from_slice(body);
+        let values = vec![(
+            "blob".into(),
+            Value::Custom(CustomValue {
+                type_tag: "MyBlob".into(),
+                encoded,
+                display: String::new(),
+            }),
+        )];
+        let bytes = encode_record_by_snapshot(&values, &snap).unwrap();
+        let decoded = decode_record_by_snapshot(&bytes, &snap).unwrap();
+        assert_eq!(decoded, values);
+    }
+
+    #[test]
+    fn test_decode_truncated_returns_too_short() {
+        let snap = snap_with(vec![col("id", DataTypeSnapshot::Uint32, false)]);
+        let err = decode_record_by_snapshot(&[0u8, 0u8], &snap).unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::DecodeError(DecodeError::TooShort)
+        ));
+    }
+
+    #[test]
+    fn test_encode_count_mismatch_errors() {
+        let snap = snap_with(vec![col("id", DataTypeSnapshot::Uint32, false)]);
+        let err = encode_record_by_snapshot(&[], &snap).unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::DecodeError(DecodeError::IdentityDecodeError(_))
+        ));
+    }
+}

--- a/crates/wasm-dbms/wasm-dbms/src/database/migration/diff.rs
+++ b/crates/wasm-dbms/wasm-dbms/src/database/migration/diff.rs
@@ -26,7 +26,7 @@ use crate::schema::DatabaseSchema;
 ///
 /// - [`MigrationError::IncompatibleType`] when a column's data type changes to
 ///   one neither in the widening whitelist nor presumed transformable.
-/// - [`MigrationError::MissingDefault`] when a non-nullable column is added
+/// - [`MigrationError::DefaultMissing`] when a non-nullable column is added
 ///   with no `#[default]` and no `Migrate::default_value` override.
 pub(crate) fn diff<M, A>(
     stored: &[TableSchemaSnapshot],
@@ -128,7 +128,7 @@ where
                 .migrate_default_dyn(&compiled.name, &compiled_col.name)
                 .is_none()
         {
-            return Err(DbmsError::Migration(MigrationError::MissingDefault {
+            return Err(DbmsError::Migration(MigrationError::DefaultMissing {
                 table: compiled.name.clone(),
                 column: compiled_col.name.clone(),
             }));
@@ -408,7 +408,7 @@ mod tests {
         let result = diff(&stored, &compiled, &schema());
         assert!(matches!(
             result,
-            Err(DbmsError::Migration(MigrationError::MissingDefault { ref table, ref column }))
+            Err(DbmsError::Migration(MigrationError::DefaultMissing { ref table, ref column }))
                 if table == "users" && column == "email"
         ));
     }

--- a/crates/wasm-dbms/wasm-dbms/src/database/migration/plan.rs
+++ b/crates/wasm-dbms/wasm-dbms/src/database/migration/plan.rs
@@ -23,14 +23,14 @@ pub(crate) fn order_ops(ops: &mut [MigrationOp]) {
 /// Validates the planned ops against `policy` before any memory mutation.
 ///
 /// Defense-in-depth: catches destructive ops the diff layer can produce, plus
-/// re-checks `MissingDefault` for `AddColumn` ops in case the diff was
+/// re-checks `DefaultMissing` for `AddColumn` ops in case the diff was
 /// short-circuited (e.g. by a future caller bypassing the diff entry point).
 ///
 /// # Errors
 ///
 /// - [`MigrationError::DestructiveOpDenied`] when `policy.allow_destructive`
 ///   is `false` and the plan includes a `DropTable` or `DropColumn`.
-/// - [`MigrationError::MissingDefault`] when a non-nullable `AddColumn` op
+/// - [`MigrationError::DefaultMissing`] when a non-nullable `AddColumn` op
 ///   lacks a static `#[default]` (the dispatch fallback is verified later, at
 ///   apply time, since it requires a schema reference).
 pub(crate) fn validate(ops: &[MigrationOp], policy: MigrationPolicy) -> DbmsResult<()> {
@@ -49,7 +49,7 @@ pub(crate) fn validate(ops: &[MigrationOp], policy: MigrationPolicy) -> DbmsResu
             MigrationOp::AddColumn { table, column }
                 if !column.nullable && column.default.is_none() =>
             {
-                return Err(DbmsError::Migration(MigrationError::MissingDefault {
+                return Err(DbmsError::Migration(MigrationError::DefaultMissing {
                     table: table.clone(),
                     column: column.name.clone(),
                 }));
@@ -287,7 +287,7 @@ mod tests {
         let result = validate(&ops, MigrationPolicy::default());
         assert!(matches!(
             result,
-            Err(DbmsError::Migration(MigrationError::MissingDefault { ref column, .. })) if column == "email"
+            Err(DbmsError::Migration(MigrationError::DefaultMissing { ref column, .. })) if column == "email"
         ));
     }
 

--- a/crates/wasm-dbms/wasm-dbms/src/database/migration/widen.rs
+++ b/crates/wasm-dbms/wasm-dbms/src/database/migration/widen.rs
@@ -1,0 +1,139 @@
+// Rust guideline compliant 2026-04-27
+
+//! Compatible-widening whitelist for `MigrationOp::WidenColumn`.
+//!
+//! Mirrors the table from the schema-migrations design:
+//!
+//! | From → To              | Semantics       |
+//! |------------------------|-----------------|
+//! | `IntN → IntM`, M > N   | sign-extend     |
+//! | `UintN → UintM`, M > N | zero-extend     |
+//! | `UintN → IntM`, M > N  | zero-extend     |
+//! | `Float32 → Float64`    | widen           |
+//!
+//! Anything else returns [`MigrationError::WideningIncompatible`].
+
+use wasm_dbms_api::prelude::{
+    DataTypeSnapshot, DbmsError, DbmsResult, Int16, Int32, Int64, MigrationError, Uint16, Uint32,
+    Uint64, Value,
+};
+
+/// Apply a single-column widening conversion. `Value::Null` is preserved
+/// regardless of the type pair (a nullable column keeps its null after
+/// widening).
+pub(crate) fn widen_value(
+    table: &str,
+    column: &str,
+    old_type: &DataTypeSnapshot,
+    new_type: &DataTypeSnapshot,
+    value: Value,
+) -> DbmsResult<Value> {
+    if matches!(value, Value::Null) {
+        return Ok(Value::Null);
+    }
+    use DataTypeSnapshot as D;
+    let widened = match (old_type, new_type, value) {
+        (D::Int8, D::Int16, Value::Int8(v)) => Value::Int16(Int16(v.0 as i16)),
+        (D::Int8, D::Int32, Value::Int8(v)) => Value::Int32(Int32(v.0 as i32)),
+        (D::Int8, D::Int64, Value::Int8(v)) => Value::Int64(Int64(v.0 as i64)),
+        (D::Int16, D::Int32, Value::Int16(v)) => Value::Int32(Int32(v.0 as i32)),
+        (D::Int16, D::Int64, Value::Int16(v)) => Value::Int64(Int64(v.0 as i64)),
+        (D::Int32, D::Int64, Value::Int32(v)) => Value::Int64(Int64(v.0 as i64)),
+        (D::Uint8, D::Uint16, Value::Uint8(v)) => Value::Uint16(Uint16(v.0 as u16)),
+        (D::Uint8, D::Uint32, Value::Uint8(v)) => Value::Uint32(Uint32(v.0 as u32)),
+        (D::Uint8, D::Uint64, Value::Uint8(v)) => Value::Uint64(Uint64(v.0 as u64)),
+        (D::Uint16, D::Uint32, Value::Uint16(v)) => Value::Uint32(Uint32(v.0 as u32)),
+        (D::Uint16, D::Uint64, Value::Uint16(v)) => Value::Uint64(Uint64(v.0 as u64)),
+        (D::Uint32, D::Uint64, Value::Uint32(v)) => Value::Uint64(Uint64(v.0 as u64)),
+        (D::Uint8, D::Int16, Value::Uint8(v)) => Value::Int16(Int16(v.0 as i16)),
+        (D::Uint8, D::Int32, Value::Uint8(v)) => Value::Int32(Int32(v.0 as i32)),
+        (D::Uint8, D::Int64, Value::Uint8(v)) => Value::Int64(Int64(v.0 as i64)),
+        (D::Uint16, D::Int32, Value::Uint16(v)) => Value::Int32(Int32(v.0 as i32)),
+        (D::Uint16, D::Int64, Value::Uint16(v)) => Value::Int64(Int64(v.0 as i64)),
+        (D::Uint32, D::Int64, Value::Uint32(v)) => Value::Int64(Int64(v.0 as i64)),
+        (old, new, _) => {
+            return Err(DbmsError::Migration(MigrationError::WideningIncompatible {
+                table: table.to_string(),
+                column: column.to_string(),
+                old_type: old.clone(),
+                new_type: new.clone(),
+            }));
+        }
+    };
+    Ok(widened)
+}
+
+#[cfg(test)]
+mod tests {
+    use wasm_dbms_api::prelude::Int32;
+
+    use super::*;
+
+    #[test]
+    fn test_widen_uint32_to_uint64_zero_extends() {
+        let v = widen_value(
+            "t",
+            "c",
+            &DataTypeSnapshot::Uint32,
+            &DataTypeSnapshot::Uint64,
+            Value::Uint32(Uint32(7)),
+        )
+        .unwrap();
+        assert_eq!(v, Value::Uint64(Uint64(7)));
+    }
+
+    #[test]
+    fn test_widen_int16_to_int64_sign_extends_negative() {
+        let v = widen_value(
+            "t",
+            "c",
+            &DataTypeSnapshot::Int16,
+            &DataTypeSnapshot::Int64,
+            Value::Int16(Int16(-3)),
+        )
+        .unwrap();
+        assert_eq!(v, Value::Int64(Int64(-3)));
+    }
+
+    #[test]
+    fn test_widen_uint16_to_int32_zero_extends_into_signed() {
+        let v = widen_value(
+            "t",
+            "c",
+            &DataTypeSnapshot::Uint16,
+            &DataTypeSnapshot::Int32,
+            Value::Uint16(Uint16(40_000)),
+        )
+        .unwrap();
+        assert_eq!(v, Value::Int32(Int32(40_000)));
+    }
+
+    #[test]
+    fn test_widen_null_preserved() {
+        let v = widen_value(
+            "t",
+            "c",
+            &DataTypeSnapshot::Int32,
+            &DataTypeSnapshot::Int64,
+            Value::Null,
+        )
+        .unwrap();
+        assert_eq!(v, Value::Null);
+    }
+
+    #[test]
+    fn test_widen_int32_to_uint8_returns_incompatible() {
+        let err = widen_value(
+            "t",
+            "c",
+            &DataTypeSnapshot::Int32,
+            &DataTypeSnapshot::Uint8,
+            Value::Int32(Int32(7)),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            DbmsError::Migration(MigrationError::WideningIncompatible { .. })
+        ));
+    }
+}

--- a/crates/wasm-dbms/wasm-dbms/src/transaction/journal.rs
+++ b/crates/wasm-dbms/wasm-dbms/src/transaction/journal.rs
@@ -146,6 +146,11 @@ where
         self.mm.zero(page, offset, data)
     }
 
+    fn zero_raw(&mut self, page: Page, offset: PageOffset, len: PageOffset) -> MemoryResult<()> {
+        self.journal.record(self.mm, page, offset, len as usize)?;
+        self.mm.zero_raw(page, offset, len)
+    }
+
     fn read_at_raw(
         &mut self,
         page: Page,

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -181,12 +181,12 @@ The planner walks the slice in order: it first looks for a stored column named `
 
 The framework auto-widens these without user code:
 
-| From → To              | Semantics              |
-| ---------------------- | ---------------------- |
-| `IntN` → `IntM`, M > N | sign-extend            |
-| `UintN` → `UintM`, M > N | zero-extend          |
-| `UintN` → `IntM`, M > N | zero-extend into signed |
-| `Float32` → `Float64`  | widen                  |
+| From → To                | Semantics               |
+| ------------------------ | ----------------------- |
+| `IntN` → `IntM`, M > N   | sign-extend             |
+| `UintN` → `UintM`, M > N | zero-extend             |
+| `UintN` → `IntM`, M > N  | zero-extend into signed |
+| `Float32` → `Float64`    | widen                   |
 
 Just edit the field type and migrate. Plan output is `WidenColumn { ... }`.
 

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -149,7 +149,7 @@ impl Migrate for Event {
 }
 ```
 
-Returning `None` here falls back to the `#[default]` attribute. Returning `None` from both produces `MigrationError::MissingDefault`.
+Returning `None` here falls back to the `#[default]` attribute. Returning `None` from both produces `MigrationError::DefaultMissing`.
 
 > **Note:** without `#[migrate]`, the `Table` macro emits an empty `impl Migrate for T {}` for you. Adding a hand-written impl on top of it would be a duplicate.
 
@@ -388,7 +388,7 @@ A failed `migrate()` call rolls back every page touched in the journal session. 
 
 Recovery is iterative:
 
-1. Read the error variant. `IncompatibleType`, `MissingDefault`, `ConstraintViolation`, `DestructiveOpDenied`, and `TransformAborted` each call out the offending table/column/reason.
+1. Read the error variant. `IncompatibleType`, `DefaultMissing`, `ConstraintViolation`, `DestructiveOpDenied`, and `TransformAborted` each call out the offending table/column/reason.
 2. Fix the cause: add `#[default]`, write a `transform_column` arm, clean offending rows via ACL-allowed admin endpoints, or relax the policy.
 3. Redeploy the binary (or just retry `migrate` if the fix is data-side, not schema-side).
 
@@ -433,7 +433,7 @@ Round-trip the snapshots through `Encode::encode` / `Encode::decode` to confirm 
 ## Common Pitfalls
 
 - **Renaming without `#[renamed_from]`.** The planner has no way to know your intent; it will emit `DropColumn` + `AddColumn` and silently lose data the moment `allow_destructive: true` is set.
-- **Adding a non-nullable column without a default.** Pre-flight will reject the plan with `MissingDefault`. Either provide `#[default]`, override `Migrate::default_value`, or make the column `Nullable<T>`.
+- **Adding a non-nullable column without a default.** Pre-flight will reject the plan with `DefaultMissing`. Either provide `#[default]`, override `Migrate::default_value`, or make the column `Nullable<T>`.
 - **Tightening on dirty data.** A `nullable: false` flip after a release that allowed nulls will fail unless every row already satisfies the constraint. Backfill in a prior release.
 - **Reordering `DataTypeSnapshot` discriminants.** The on-disk format depends on the exact tag bytes. Treat the enum as frozen — new variants take fresh tags, removed ones leave a reserved hole.
 - **Bumping `#[alignment = N]`.** This changes the on-disk record layout for the table. Until `WidenColumn` is generalised to handle alignment changes, this requires a manual rewrite. Avoid unless absolutely necessary.

--- a/docs/ic/guides/client-api.md
+++ b/docs/ic/guides/client-api.md
@@ -18,6 +18,7 @@
     - [Delete](#delete)
     - [Transactions](#transactions)
     - [ACL Management](#acl-management)
+    - [Schema Migrations](#schema-migrations)
   - [Error Handling](#error-handling)
   - [Examples](#examples)
     - [Inter-Canister Communication](#inter-canister-communication)
@@ -163,6 +164,11 @@ pub trait Client {
     async fn acl_add_principal(&self, principal: Principal) -> Result<Result<(), IcDbmsError>>;
     async fn acl_remove_principal(&self, principal: Principal) -> Result<Result<(), IcDbmsError>>;
     async fn acl_allowed_principals(&self) -> Result<Vec<Principal>>;
+
+    // Schema Migrations
+    async fn has_drift(&self) -> Result<Result<bool, IcDbmsError>>;
+    async fn pending_migrations(&self) -> Result<Result<Vec<MigrationOp>, IcDbmsError>>;
+    async fn migrate(&self, policy: MigrationPolicy) -> Result<Result<(), IcDbmsError>>;
 }
 ```
 
@@ -312,6 +318,39 @@ match some_condition {
     false => client.rollback(tx_id).await??,
 }
 ```
+
+### Schema Migrations
+
+Three admin-gated methods inspect and apply schema drift. The Candid
+endpoints behind them (`has_drift` query, `pending_migrations` query, `migrate`
+update) are emitted by `#[derive(DbmsCanister)]`. See the
+[IC migrations guide](./migrations.md) for the upgrade workflow.
+
+```rust
+use ic_dbms_api::prelude::{MigrationOp, MigrationPolicy};
+
+// O(1) once cached on the canister side. True iff a migration is needed.
+let drift: bool = client.has_drift().await??;
+if !drift {
+    return Ok(());
+}
+
+// Plan without applying. Always recomputes; safe to call during drift.
+let plan: Vec<MigrationOp> = client.pending_migrations().await??;
+for op in &plan {
+    eprintln!("  {op:?}");
+}
+
+// Apply. Refuses DropTable / DropColumn unless allow_destructive is set.
+client.migrate(MigrationPolicy::default()).await??;
+
+// Equivalent to:
+client
+    .migrate(MigrationPolicy { allow_destructive: false })
+    .await??;
+```
+
+`migrate` is idempotent — when there is no drift, the call is a cheap no-op.
 
 ### ACL Management
 

--- a/docs/ic/guides/migrations.md
+++ b/docs/ic/guides/migrations.md
@@ -1,0 +1,330 @@
+# Schema Migrations (IC)
+
+> **Note:** This is the IC-specific migrations guide. The schema-design rules
+> (`#[default]`, `#[renamed_from]`, `#[migrate]`, the `Migrate` trait,
+> `MigrationOp` semantics) are identical to the generic backend; see the
+> [generic Schema Migrations Guide](../../guides/migrations.md) and the
+> [Migrations Reference](../../reference/migrations.md) for the conceptual
+> material. This page covers only what changes when the database lives inside
+> an IC canister.
+
+- [Schema Migrations (IC)](#schema-migrations-ic)
+  - [Overview](#overview)
+  - [Generated Endpoints](#generated-endpoints)
+  - [Candid Types](#candid-types)
+  - [Upgrade Workflow](#upgrade-workflow)
+  - [Calling From a Client](#calling-from-a-client)
+    - [Inter-Canister](#inter-canister)
+    - [External Agent](#external-agent)
+    - [PocketIC Tests](#pocketic-tests)
+  - [Driving Migration From `post_upgrade`](#driving-migration-from-post_upgrade)
+  - [Operator-Driven Migration](#operator-driven-migration)
+  - [Error Handling](#error-handling)
+  - [Drift While Serving Traffic](#drift-while-serving-traffic)
+
+---
+
+## Overview
+
+A canister upgrade replaces the WASM but keeps stable memory. If the new
+binary's `#[derive(Table)]` schemas differ from the snapshots persisted on
+disk, the DBMS enters drift state and refuses CRUD until you call `migrate`.
+ACL endpoints stay available so you can rotate principals without first
+healing the schema.
+
+The drift hash is recomputed lazily, on the first `has_drift` /
+`pending_migrations` / CRUD call after boot, and cached on the DBMS context.
+There is no post-upgrade hook: the canister simply boots, declares drift on
+first access, and waits for the operator (or a `post_upgrade` snippet you
+write yourself) to call `migrate`.
+
+---
+
+## Generated Endpoints
+
+`#[derive(DbmsCanister)]` emits three additional endpoints alongside the
+per-table CRUD methods:
+
+| Endpoint             | Kind   | Purpose                                                   |
+| -------------------- | ------ | --------------------------------------------------------- |
+| `has_drift`          | query  | `O(1)` once cached; `true` iff a migration is needed.     |
+| `pending_migrations` | query  | Returns the planned `Vec<MigrationOp>` without applying.  |
+| `migrate`            | update | Plans, validates, sorts, and applies the diff atomically. |
+
+All three are **admin-gated** through the same ACL check used by the rest of
+the CRUD surface — anonymous and unlisted principals are rejected before the
+DBMS is touched.
+
+`migrate` is an `update` because it journals writes. `has_drift` and
+`pending_migrations` are `query` calls and consume no cycles for the caller
+beyond the standard query overhead.
+
+---
+
+## Candid Types
+
+The Candid signatures are:
+
+```candid
+type MigrationPolicy = record { allow_destructive : bool };
+
+type MigrationOp = variant {
+  CreateTable   : record { name : text; schema : TableSchemaSnapshot };
+  DropTable     : record { name : text };
+  AddColumn     : record { table : text; column : ColumnSnapshot };
+  DropColumn    : record { table : text; column : text };
+  RenameColumn  : record { table : text; old : text; new : text };
+  AlterColumn   : record { table : text; column : text; changes : ColumnChanges };
+  WidenColumn   : record { table : text; column : text; old_type : DataTypeSnapshot; new_type : DataTypeSnapshot };
+  TransformColumn : record { table : text; column : text; old_type : DataTypeSnapshot; new_type : DataTypeSnapshot };
+  AddIndex      : record { table : text; index : IndexSnapshot };
+  DropIndex     : record { table : text; index : IndexSnapshot };
+};
+
+has_drift           : () -> (variant { Ok : bool;             Err : IcDbmsError }) query;
+pending_migrations  : () -> (variant { Ok : vec MigrationOp;  Err : IcDbmsError }) query;
+migrate             : (MigrationPolicy)
+                    -> (variant { Ok;                         Err : IcDbmsError });
+```
+
+Snapshot types (`TableSchemaSnapshot`, `ColumnSnapshot`, `IndexSnapshot`,
+`ForeignKeySnapshot`, `DataTypeSnapshot`, `OnDeleteSnapshot`,
+`ColumnChanges`) are the same Candid records the snapshot reference describes
+in the [generic schema reference](../../reference/schema.md). They are
+exported automatically by `ic_cdk::export_candid!()`.
+
+---
+
+## Upgrade Workflow
+
+The end-to-end flow for a schema-changing release:
+
+1. **Edit the schema.** Modify the `#[derive(Table)]` structs and add
+   `#[default]` / `#[renamed_from]` / `#[migrate]` as needed.
+2. **Build the canister.** `just build_all` compiles to `wasm32-unknown-unknown`,
+   shrinks the WASM, and extracts the new `.did`.
+3. **Deploy via `dfx canister install --mode upgrade`.** Stable memory carries
+   over untouched.
+4. **Inspect drift.** Call `has_drift` from `dfx`, an admin tool, or a
+   `Client`. Skip the rest if `false`.
+5. **Plan.** Call `pending_migrations` and review the returned ops. Look in
+   particular for unintended `DropTable` / `DropColumn` ops, which usually
+   signal a typo in `#[table = "..."]` or a missing `#[renamed_from]`.
+6. **Apply.** Call `migrate(record { allow_destructive = false })`. If the
+   plan contains a deliberate destructive op, set `allow_destructive = true`
+   only after the review step.
+7. **Verify.** Re-run `has_drift`; expect `false`. CRUD endpoints now work
+   again.
+
+`migrate` is idempotent: when there is no drift, the call is a cheap no-op.
+
+---
+
+## Calling From a Client
+
+The three methods are part of the `Client` trait. The signatures are
+identical across `IcDbmsCanisterClient`, `IcDbmsAgentClient`, and
+`IcDbmsPocketIcClient`:
+
+```rust
+async fn has_drift(&self) -> Result<IcDbmsResult<bool>>;
+async fn pending_migrations(&self) -> Result<IcDbmsResult<Vec<MigrationOp>>>;
+async fn migrate(&self, policy: MigrationPolicy) -> Result<IcDbmsResult<()>>;
+```
+
+The outer `Result` wraps transport / canister-call failures; the inner
+`IcDbmsResult` wraps `IcDbmsError` (including
+`IcDbmsError::Migration(MigrationError::...)`).
+
+### Inter-Canister
+
+```rust
+use ic_dbms_api::prelude::{MigrationPolicy};
+use ic_dbms_client::{Client as _, IcDbmsCanisterClient};
+use candid::Principal;
+
+#[ic_cdk::update]
+async fn heal_schema(canister: Principal) -> Result<u64, String> {
+    let client = IcDbmsCanisterClient::new(canister);
+
+    if !client.has_drift().await.map_err(|e| e.to_string())??.then_some(()).is_some() {
+        return Ok(0);
+    }
+
+    let ops = client.pending_migrations().await.map_err(|e| e.to_string())??;
+    client
+        .migrate(MigrationPolicy::default())
+        .await
+        .map_err(|e| e.to_string())??;
+
+    Ok(ops.len() as u64)
+}
+```
+
+### External Agent
+
+```rust
+use ic_agent::Agent;
+use ic_dbms_api::prelude::MigrationPolicy;
+use ic_dbms_client::{Client as _, IcDbmsAgentClient};
+use candid::Principal;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let agent = Agent::builder()
+        .with_url("https://ic0.app")
+        .with_identity(load_identity()?)
+        .build()?;
+    let canister = Principal::from_text("rrkah-fqaaa-aaaaa-aaaaq-cai")?;
+    let client = IcDbmsAgentClient::new(canister, &agent);
+
+    if client.has_drift().await?? {
+        let plan = client.pending_migrations().await??;
+        eprintln!("planning {} ops", plan.len());
+        for op in &plan {
+            eprintln!("  {op:?}");
+        }
+        client
+            .migrate(MigrationPolicy { allow_destructive: false })
+            .await??;
+    }
+
+    Ok(())
+}
+```
+
+### PocketIC Tests
+
+```rust
+use ic_dbms_api::prelude::MigrationPolicy;
+use ic_dbms_client::{Client as _, IcDbmsPocketIcClient};
+
+#[tokio::test]
+async fn upgrade_heals_drift() {
+    let pic = pocket_ic::PocketIc::new();
+    let canister = install_v1_canister(&pic);
+    insert_fixtures(&pic, canister).await;
+
+    upgrade_to_v2(&pic, canister);
+
+    let client = IcDbmsPocketIcClient::new(canister, admin_principal(), &pic);
+    assert!(client.has_drift().await.unwrap().unwrap());
+    let plan = client.pending_migrations().await.unwrap().unwrap();
+    assert!(!plan.is_empty());
+    client
+        .migrate(MigrationPolicy::default())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(!client.has_drift().await.unwrap().unwrap());
+}
+```
+
+---
+
+## Driving Migration From `post_upgrade`
+
+For canisters where the deployment pipeline already owns the upgrade flow,
+you can wire `migrate` directly into a `#[ic_cdk::post_upgrade]` hook so the
+schema heals before the first CRUD call lands.
+
+```rust
+use ic_dbms_api::prelude::{MigrationPolicy};
+use ic_dbms_canister::prelude::{DatabaseSchema as _, DBMS_CONTEXT, WasmDbmsDatabase};
+
+#[derive(DatabaseSchema, DbmsCanister)]
+#[tables(User = "users", Post = "posts")]
+pub struct MyCanister;
+
+#[ic_cdk::post_upgrade]
+fn post_upgrade() {
+    DBMS_CONTEXT.with(|ctx| {
+        // Re-register tables so the registry matches the compiled schema
+        // before drift detection runs.
+        MyCanister::register_tables(ctx).expect("failed to register tables");
+
+        let mut db = WasmDbmsDatabase::oneshot(ctx, MyCanister);
+        if db.has_drift().expect("drift check failed") {
+            db.migrate(MigrationPolicy::default())
+                .expect("migration failed");
+        }
+    });
+}
+```
+
+This pattern is convenient but **trades safety for convenience**:
+
+- An accidental schema change ships destructive ops to production with no
+  human review.
+- A bug in `transform_column` traps the canister on upgrade.
+- `MigrationPolicy::default()` (i.e. `allow_destructive: false`) refuses
+  destructive ops, but everything else applies silently.
+
+For high-stakes deployments prefer the operator-driven flow below.
+
+---
+
+## Operator-Driven Migration
+
+The recommended flow for production canisters:
+
+1. Upgrade the canister. The new WASM boots in drift state.
+2. Run a one-shot script (CLI / admin canister / `dfx`) that calls
+   `pending_migrations`, prints the plan, and waits for confirmation.
+3. On confirmation, call `migrate`.
+
+`dfx` example:
+
+```bash
+dfx canister call my_dbms has_drift
+# (variant { Ok = true })
+
+dfx canister call my_dbms pending_migrations
+# (variant { Ok = vec { ... } })
+
+dfx canister call my_dbms migrate '(record { allow_destructive = false })'
+# (variant { Ok })
+```
+
+Until `migrate` succeeds the canister rejects every CRUD endpoint with
+`MigrationError::SchemaDrift`, so any traffic that arrives between the
+upgrade and the operator action receives a clear, structured error.
+
+---
+
+## Error Handling
+
+Migration errors propagate through `IcDbmsError::Migration(MigrationError)`.
+The variants worth handling explicitly on the client:
+
+| Variant                  | Meaning                                                             | Caller action                                                                   |
+| ------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `SchemaDrift`            | CRUD called while drift is set.                                     | Call `migrate`.                                                                 |
+| `IncompatibleType`       | Column type changed without a widening or transform.                | Add a `transform_column` arm or a release that widens via an intermediate type. |
+| `MissingDefault`         | New non-nullable column with no `#[default]` or `default_value`.    | Add the default; redeploy.                                                      |
+| `ConstraintViolation`    | Tightening rejected an existing row.                                | Backfill the offending rows in a prior release.                                 |
+| `DestructiveOpDenied`    | Plan contained `DropTable` / `DropColumn` and policy disallowed it. | Re-run with `allow_destructive: true` after operator review.                    |
+| `TransformAborted`       | User `transform_column` returned `Err`.                             | Fix the transform; redeploy.                                                    |
+| `DataRewriteUnsupported` | Column-mutating op against snapshot-driven rewrite (issue #91).     | Track upstream; out of scope for v1.                                            |
+
+Tip: never `unwrap` `migrate` in a `post_upgrade` hook — a panic there bricks
+the canister. Trap with a descriptive message instead, or fall back to the
+operator-driven flow.
+
+---
+
+## Drift While Serving Traffic
+
+CRUD endpoints fail fast when drift is set: the very first line of every
+`select_*` / `insert_*` / `update_*` / `delete_*` / `aggregate_*` handler
+checks the cached drift flag and returns `Err(MigrationError::SchemaDrift)`
+without touching the journal. Cost is a single boolean load.
+
+ACL endpoints (`acl_add_principal`, `acl_remove_principal`,
+`acl_allowed_principals`) bypass the drift check so the operator can rotate
+keys without first migrating. The migration endpoints themselves are also
+exempt — `pending_migrations` is safe to call regardless of state.
+
+After a successful `migrate`, the in-memory drift flag is cleared inside the
+same journal session that wrote the new snapshots, so the next CRUD call
+proceeds against the new schema with no extra round trip.

--- a/docs/ic/guides/migrations.md
+++ b/docs/ic/guides/migrations.md
@@ -297,15 +297,17 @@ upgrade and the operator action receives a clear, structured error.
 Migration errors propagate through `IcDbmsError::Migration(MigrationError)`.
 The variants worth handling explicitly on the client:
 
-| Variant                  | Meaning                                                             | Caller action                                                                   |
-| ------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `SchemaDrift`            | CRUD called while drift is set.                                     | Call `migrate`.                                                                 |
-| `IncompatibleType`       | Column type changed without a widening or transform.                | Add a `transform_column` arm or a release that widens via an intermediate type. |
-| `MissingDefault`         | New non-nullable column with no `#[default]` or `default_value`.    | Add the default; redeploy.                                                      |
-| `ConstraintViolation`    | Tightening rejected an existing row.                                | Backfill the offending rows in a prior release.                                 |
-| `DestructiveOpDenied`    | Plan contained `DropTable` / `DropColumn` and policy disallowed it. | Re-run with `allow_destructive: true` after operator review.                    |
-| `TransformAborted`       | User `transform_column` returned `Err`.                             | Fix the transform; redeploy.                                                    |
-| `DataRewriteUnsupported` | Column-mutating op against snapshot-driven rewrite (issue #91).     | Track upstream; out of scope for v1.                                            |
+| Variant                 | Meaning                                                                          | Caller action                                                                   |
+| ----------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `SchemaDrift`           | CRUD called while drift is set.                                                  | Call `migrate`.                                                                 |
+| `IncompatibleType`      | Column type changed without a widening or transform.                             | Add a `transform_column` arm or a release that widens via an intermediate type. |
+| `DefaultMissing`        | New non-nullable column with no `#[default]` or `default_value`.                 | Add the default; redeploy.                                                      |
+| `ConstraintViolation`   | Tightening rejected an existing row.                                             | Backfill the offending rows in a prior release.                                 |
+| `DestructiveOpDenied`   | Plan contained `DropTable` / `DropColumn` and policy disallowed it.              | Re-run with `allow_destructive: true` after operator review.                    |
+| `TransformAborted`      | User `transform_column` returned `Err`.                                          | Fix the transform; redeploy.                                                    |
+| `WideningIncompatible`  | `WidenColumn` outside the widening whitelist with no `transform_column` handler. | Provide a `transform_column` impl or split the change across multiple releases. |
+| `TransformReturnedNone` | `Migrate::transform_column` returned `Ok(None)` for a column that needs one.     | Implement the transform branch.                                                 |
+| `ForeignKeyViolation`   | Add-FK tightening found a row referencing a missing target.                      | Clean up orphan rows in a prior release.                                        |
 
 Tip: never `unwrap` `migrate` in a `post_upgrade` hook — a panic there bricks
 the canister. Trap with a descriptive message instead, or fall back to the

--- a/docs/ic/index.md
+++ b/docs/ic/index.md
@@ -56,12 +56,12 @@ If you are using wasm-dbms outside the Internet Computer (e.g., in a standalone 
 
 IC-DBMS is composed of four crates:
 
-| Crate | Description | Depends On |
-|-------|-------------|------------|
-| **ic-dbms-api** | Shared types, re-exports `wasm-dbms-api` types with IC additions. Provides `IcDbmsError` type alias and IC-compatible type wrappers. | `wasm-dbms-api` |
-| **ic-dbms-canister** | Core canister engine. Provides the `DbmsCanister` derive macro target, ACL management, canister init/upgrade lifecycle, and the IC stable memory provider. | `wasm-dbms`, `ic-dbms-api` |
-| **ic-dbms-macros** | Procedural macros: `#[derive(DatabaseSchema)]` (IC variant, uses IC crate paths) and `#[derive(DbmsCanister)]` for generating complete canister APIs. | `wasm-dbms-macros` |
-| **ic-dbms-client** | Client library with three implementations: `IcDbmsCanisterClient` (inter-canister), `IcDbmsAgentClient` (external via IC agent), `IcDbmsPocketIcClient` (integration testing). | `ic-dbms-api` |
+| Crate                | Description                                                                                                                                                                    | Depends On                 |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- |
+| **ic-dbms-api**      | Shared types, re-exports `wasm-dbms-api` types with IC additions. Provides `IcDbmsError` type alias and IC-compatible type wrappers.                                           | `wasm-dbms-api`            |
+| **ic-dbms-canister** | Core canister engine. Provides the `DbmsCanister` derive macro target, ACL management, canister init/upgrade lifecycle, and the IC stable memory provider.                     | `wasm-dbms`, `ic-dbms-api` |
+| **ic-dbms-macros**   | Procedural macros: `#[derive(DatabaseSchema)]` (IC variant, uses IC crate paths) and `#[derive(DbmsCanister)]` for generating complete canister APIs.                          | `wasm-dbms-macros`         |
+| **ic-dbms-client**   | Client library with three implementations: `IcDbmsCanisterClient` (inter-canister), `IcDbmsAgentClient` (external via IC agent), `IcDbmsPocketIcClient` (integration testing). | `ic-dbms-api`              |
 
 **Import convention:**
 

--- a/docs/ic/reference/schema.md
+++ b/docs/ic/reference/schema.md
@@ -9,6 +9,7 @@
   - [DbmsCanister Macro](#dbmscanister-macro)
     - [Basic Usage](#basic-usage)
     - [Generated Candid API](#generated-candid-api)
+    - [Migration Endpoints](#migration-endpoints)
   - [Candid Integration](#candid-integration)
     - [CandidType and Deserialize](#candidtype-and-deserialize)
     - [Candid Export](#candid-export)
@@ -20,7 +21,7 @@
 
 When deploying wasm-dbms on the Internet Computer, your schema definitions need additional IC-specific derives, the `#[candid]` attribute, and a canister generation macro. The core `Table` macro, column attributes (`#[primary_key]`, `#[unique]`, `#[index]`, `#[foreign_key(...)]`, `#[sanitizer(...)]`, `#[validate(...)]`, `#[custom_type]`, `#[alignment]`, plus the migration attributes `#[default]`, `#[renamed_from]`, `#[migrate]`), and generated types (`Record`, `InsertRequest`, `UpdateRequest`, `ForeignFetcher`) work exactly as described in the [generic schema reference](../../reference/schema.md). This document covers only the IC-specific additions.
 
-> **Migrations on the IC:** schema migrations work the same as on the generic backend, but the `DbmsCanister` macro additionally emits the `has_schema_drift`, `plan_migration`, and `migrate` Candid endpoints. See the [Schema Migrations Reference](../../reference/migrations.md) and the [Schema Migrations Guide](../../guides/migrations.md).
+> **Migrations on the IC:** schema migrations work the same as on the generic backend, but the `DbmsCanister` macro additionally emits the `has_drift`, `pending_migrations`, and `migrate` Candid endpoints (see [Migration Endpoints](#migration-endpoints) below). See the [Schema Migrations Reference](../../reference/migrations.md), the [generic Schema Migrations Guide](../../guides/migrations.md), and the [IC Schema Migrations Guide](../guides/migrations.md).
 
 ---
 
@@ -129,6 +130,11 @@ service : (IcDbmsCanisterArgs) -> {
   acl_add_principal : (principal) -> (Result);
   acl_remove_principal : (principal) -> (Result);
   acl_allowed_principals : () -> (vec principal) query;
+
+  // Schema migrations (shared) — see Migration Endpoints below
+  has_drift : () -> (Result_bool) query;
+  pending_migrations : () -> (Result_Vec_MigrationOp) query;
+  migrate : (MigrationPolicy) -> (Result);
 }
 ```
 
@@ -145,6 +151,100 @@ table. The `vec AggregateFunction` parameter lists `COUNT(*)` / `COUNT(col)` /
 `group_by`, `having`, `order_by`, `limit`, and `offset`. See the
 [generic Query API reference](../../reference/query.md#aggregate-types) for
 type definitions and the [aggregate pipeline](../../reference/query.md#execution-order).
+
+### Migration Endpoints
+
+`#[derive(DbmsCanister)]` adds three admin-gated migration endpoints.
+Behaviour, error semantics, and the operator workflow are documented in the
+[IC Schema Migrations Guide](../guides/migrations.md); this section is the
+Candid signature reference.
+
+```candid
+type MigrationPolicy = record {
+  allow_destructive : bool;
+};
+
+type OnDeleteSnapshot = variant { Restrict; Cascade };
+
+type DataTypeSnapshot = variant {
+  Int8; Int16; Int32; Int64;
+  Uint8; Uint16; Uint32; Uint64;
+  Float32; Float64; Decimal;
+  Boolean; Date; Datetime;
+  Blob; Text; Uuid; Json;
+  Custom : text;
+};
+
+type ForeignKeySnapshot = record {
+  table : text;
+  column : text;
+  on_delete : OnDeleteSnapshot;
+};
+
+type IndexSnapshot = record {
+  columns : vec text;
+  unique : bool;
+};
+
+type ColumnSnapshot = record {
+  name : text;
+  data_type : DataTypeSnapshot;
+  nullable : bool;
+  auto_increment : bool;
+  unique : bool;
+  primary_key : bool;
+  foreign_key : opt ForeignKeySnapshot;
+  default : opt Value;
+};
+
+type TableSchemaSnapshot = record {
+  version : nat8;
+  name : text;
+  primary_key : text;
+  alignment : nat32;
+  columns : vec ColumnSnapshot;
+  indexes : vec IndexSnapshot;
+};
+
+type ColumnChanges = record {
+  nullable : opt bool;
+  unique : opt bool;
+  auto_increment : opt bool;
+  primary_key : opt bool;
+  foreign_key : opt opt ForeignKeySnapshot;
+};
+
+type MigrationOp = variant {
+  CreateTable     : record { name : text; schema : TableSchemaSnapshot };
+  DropTable       : record { name : text };
+  AddColumn       : record { table : text; column : ColumnSnapshot };
+  DropColumn      : record { table : text; column : text };
+  RenameColumn    : record { table : text; old : text; new : text };
+  AlterColumn     : record { table : text; column : text; changes : ColumnChanges };
+  WidenColumn     : record { table : text; column : text; old_type : DataTypeSnapshot; new_type : DataTypeSnapshot };
+  TransformColumn : record { table : text; column : text; old_type : DataTypeSnapshot; new_type : DataTypeSnapshot };
+  AddIndex        : record { table : text; index : IndexSnapshot };
+  DropIndex       : record { table : text; index : IndexSnapshot };
+};
+
+has_drift          : () -> (variant { Ok : bool;            Err : IcDbmsError }) query;
+pending_migrations : () -> (variant { Ok : vec MigrationOp; Err : IcDbmsError }) query;
+migrate            : (MigrationPolicy)
+                   -> (variant { Ok;                        Err : IcDbmsError });
+```
+
+- `has_drift` is `O(1)` once the per-context drift flag is cached. CRUD
+  endpoints early-return `IcDbmsError::Migration(MigrationError::SchemaDrift)`
+  while drift is set; ACL and migration endpoints bypass the check.
+- `pending_migrations` always recomputes the diff. Safe to call during drift.
+- `migrate` plans, validates against `MigrationPolicy`, sorts ops into the
+  deterministic apply order, and runs them inside a single journaled session.
+  Failures roll the journal back and leave persisted snapshots untouched.
+
+The `IcDbmsError::Migration(MigrationError)` variants
+(`SchemaDrift`, `IncompatibleType`, `MissingDefault`, `ConstraintViolation`,
+`DestructiveOpDenied`, `TransformAborted`, `DataRewriteUnsupported`) are
+documented in the [errors reference](./errors.md).
 
 **Init arguments:**
 

--- a/docs/reference/data-types.md
+++ b/docs/reference/data-types.md
@@ -29,17 +29,17 @@ wasm-dbms provides a rich set of data types for defining table schemas. Each typ
 
 **Type categories:**
 
-| Category | Types |
-|----------|-------|
-| Integers | Uint8, Uint16, Uint32, Uint64, Int8, Int16, Int32, Int64 |
-| Decimal | Decimal |
-| Text | Text |
-| Boolean | Boolean |
-| Date/Time | Date, DateTime |
-| Binary | Blob |
-| Identifiers | Uuid |
-| Semi-structured | Json |
-| Wrapper | Nullable\<T\> |
+| Category        | Types                                                    |
+| --------------- | -------------------------------------------------------- |
+| Integers        | Uint8, Uint16, Uint32, Uint64, Int8, Int16, Int32, Int64 |
+| Decimal         | Decimal                                                  |
+| Text            | Text                                                     |
+| Boolean         | Boolean                                                  |
+| Date/Time       | Date, DateTime                                           |
+| Binary          | Blob                                                     |
+| Identifiers     | Uuid                                                     |
+| Semi-structured | Json                                                     |
+| Wrapper         | Nullable\<T\>                                            |
 
 > **Note:** The `Principal` type is available in `ic-dbms-api` for Internet Computer integration. See the [IC Data Types](../ic/reference/data-types.md) reference for details.
 
@@ -529,25 +529,25 @@ See the [Custom Data Types Guide](../guides/custom-data-types.md) for step-by-st
 
 ## Type Conversion Reference
 
-| wasm-dbms Type | Rust Type |
-|----------------|-----------|
-| `Uint8` | `u8` |
-| `Uint16` | `u16` |
-| `Uint32` | `u32` |
-| `Uint64` | `u64` |
-| `Int8` | `i8` |
-| `Int16` | `i16` |
-| `Int32` | `i32` |
-| `Int64` | `i64` |
-| `Decimal` | `rust_decimal::Decimal` |
-| `Text` | `String` |
-| `Boolean` | `bool` |
-| `Date` | `chrono::NaiveDate` |
-| `DateTime` | `chrono::DateTime<Utc>` |
-| `Blob` | `Vec<u8>` |
-| `Uuid` | `uuid::Uuid` |
-| `Json` | `serde_json::Value` |
-| `Nullable<T>` | `Option<T>` |
+| wasm-dbms Type | Rust Type               |
+| -------------- | ----------------------- |
+| `Uint8`        | `u8`                    |
+| `Uint16`       | `u16`                   |
+| `Uint32`       | `u32`                   |
+| `Uint64`       | `u64`                   |
+| `Int8`         | `i8`                    |
+| `Int16`        | `i16`                   |
+| `Int32`        | `i32`                   |
+| `Int64`        | `i64`                   |
+| `Decimal`      | `rust_decimal::Decimal` |
+| `Text`         | `String`                |
+| `Boolean`      | `bool`                  |
+| `Date`         | `chrono::NaiveDate`     |
+| `DateTime`     | `chrono::DateTime<Utc>` |
+| `Blob`         | `Vec<u8>`               |
+| `Uuid`         | `uuid::Uuid`            |
+| `Json`         | `serde_json::Value`     |
+| `Nullable<T>`  | `Option<T>`             |
 
 > **Note:** For IC canister usage, these types also map to Candid types. See the [IC Data Types](../ic/reference/data-types.md) reference for the Candid mapping.
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -7,10 +7,13 @@
   - [Migration Errors](#migration-errors)
     - [SchemaDrift](#schemadrift)
     - [IncompatibleType](#incompatibletype)
-    - [MissingDefault](#missingdefault)
+    - [DefaultMissing](#defaultmissing)
     - [ConstraintViolation](#constraintviolation)
     - [DestructiveOpDenied](#destructiveopdenied)
     - [TransformAborted](#transformaborted)
+    - [WideningIncompatible](#wideningincompatible)
+    - [TransformReturnedNone](#transformreturnednone)
+    - [ForeignKeyViolation](#foreignkeyviolation)
   - [Query Errors](#query-errors)
     - [PrimaryKeyConflict](#primarykeyconflict)
     - [UniqueConstraintViolation](#uniqueconstraintviolation)
@@ -66,10 +69,13 @@ DbmsError
 ├── Migration(MigrationError)
 │   ├── SchemaDrift
 │   ├── IncompatibleType { table, column, old, new }
-│   ├── MissingDefault { table, column }
+│   ├── DefaultMissing { table, column }
 │   ├── ConstraintViolation { table, column, reason }
 │   ├── DestructiveOpDenied { op }
-│   └── TransformAborted { table, column, reason }
+│   ├── TransformAborted { table, column, reason }
+│   ├── WideningIncompatible { table, column, old_type, new_type }
+│   ├── TransformReturnedNone { table, column }
+│   └── ForeignKeyViolation { table, column, target_table, value }
 └── Table(TableError)
 ```
 
@@ -140,10 +146,23 @@ pub enum MigrationError {
         old: DataTypeSnapshot,
         new: DataTypeSnapshot,
     },
-    MissingDefault { table: String, column: String },
+    DefaultMissing { table: String, column: String },
     ConstraintViolation { table: String, column: String, reason: String },
     DestructiveOpDenied { op: String },
     TransformAborted { table: String, column: String, reason: String },
+    WideningIncompatible {
+        table: String,
+        column: String,
+        old_type: DataTypeSnapshot,
+        new_type: DataTypeSnapshot,
+    },
+    TransformReturnedNone { table: String, column: String },
+    ForeignKeyViolation {
+        table: String,
+        column: String,
+        target_table: String,
+        value: String,
+    },
 }
 ```
 
@@ -174,7 +193,7 @@ match database.insert::<User>(req) {
 - If the change is conceptually a widen, double-check the from/to types match the whitelist.
 - Otherwise mark the table with `#[migrate]` and provide a `transform_column` impl that maps the old `Value` to the new type.
 
-### MissingDefault
+### DefaultMissing
 
 **Cause:** Planning an `AddColumn` op for a non-nullable column that has neither a `#[default = ...]` attribute nor a `Migrate::default_value` override.
 
@@ -210,6 +229,34 @@ match database.insert::<User>(req) {
 
 - Inspect the embedded `reason` string to see which row failed.
 - Fix the offending data manually (or via a helper canister method) before retrying `migrate`.
+
+### WideningIncompatible
+
+**Cause:** A `WidenColumn` op named a `(old_type, new_type)` pair that is **not** in the [widening whitelist](./migrations.md#compatible-widening-whitelist), and the table did not provide a `Migrate::transform_column` impl that handled it. The journaled session rolls back; stored data and `schema_hash` are unchanged.
+
+**Solutions:**
+
+- Pick a target type that fits the whitelist (e.g. `Uint32 → Uint64` rather than `Uint32 → Uint8`).
+- Mark the table `#[migrate]` and provide a `transform_column` arm that maps the old `Value` into the new type.
+- Stage the change across two releases: convert via a transform first, then narrow as a separate widening with valid bounds.
+
+### TransformReturnedNone
+
+**Cause:** `Migrate::transform_column` returned `Ok(None)` for a column that needed a transform (no widening rule applied). The migration aborts and rolls back.
+
+**Solutions:**
+
+- Implement a concrete `Ok(Some(_))` arm for the column in the table's `Migrate` impl.
+- Or pick a target type that fits the widening whitelist so the framework converts automatically.
+
+### ForeignKeyViolation
+
+**Cause:** An add-FK tightening (`AlterColumn` with `foreign_key: Some(Some(_))`) found a row whose value is absent from the target table's referenced column. The journaled session rolls back; stored data and `schema_hash` are unchanged.
+
+**Solutions:**
+
+- Clean up the orphan rows in a prior release before adding the FK.
+- Inspect `value` in the error to identify the offending record(s).
 
 ---
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -33,15 +33,15 @@
 
 wasm-dbms uses a structured error system to provide clear information about what went wrong. Errors are categorized by their source:
 
-| Category | Description |
-| -------- | ----------- |
-| Query | Database operation errors (constraints, missing data) |
-| Transaction | Transaction state errors |
-| Validation | Data validation failures |
-| Sanitization | Data sanitization failures |
-| Memory | Low-level memory errors |
-| Migration | Schema migration / drift detection errors |
-| Table | Schema/table definition errors |
+| Category     | Description                                           |
+| ------------ | ----------------------------------------------------- |
+| Query        | Database operation errors (constraints, missing data) |
+| Transaction  | Transaction state errors                              |
+| Validation   | Data validation failures                              |
+| Sanitization | Data sanitization failures                            |
+| Memory       | Low-level memory errors                               |
+| Migration    | Schema migration / drift detection errors             |
+| Table        | Schema/table definition errors                        |
 
 ---
 

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -106,14 +106,14 @@ wasm-dbms provides powerful JSON filtering through the `JsonFilter` enum:
 
 Paths use dot notation with bracket array indices:
 
-| Path | Meaning |
-|------|---------|
-| `"name"` | Root-level field `name` |
-| `"user.name"` | Nested field at `user.name` |
-| `"items[0]"` | First element of `items` array |
-| `"users[0].name"` | `name` field of first user |
-| `"data[0][1]"` | Nested array access |
-| `"[0]"` | First element of root array |
+| Path              | Meaning                        |
+| ----------------- | ------------------------------ |
+| `"name"`          | Root-level field `name`        |
+| `"user.name"`     | Nested field at `user.name`    |
+| `"items[0]"`      | First element of `items` array |
+| `"users[0].name"` | `name` field of first user     |
+| `"data[0][1]"`    | Nested array access            |
+| `"[0]"`           | First element of root array    |
 
 **Path examples:**
 
@@ -151,14 +151,14 @@ let filter = Filter::json("metadata", JsonFilter::contains(pattern));
 
 **Containment behavior:**
 
-| Target | Pattern | Result |
-|--------|---------|--------|
-| `{"a": 1, "b": 2}` | `{"a": 1}` | Match |
-| `{"a": 1}` | `{"a": 1, "b": 2}` | No match |
-| `{"user": {"name": "Alice", "age": 30}}` | `{"user": {"name": "Alice"}}` | Match |
-| `[1, 2, 3]` | `[3, 1]` | Match (order-independent) |
-| `[1, 2]` | `[1, 2, 3]` | No match |
-| `{"tags": ["a", "b", "c"]}` | `{"tags": ["b"]}` | Match |
+| Target                                   | Pattern                       | Result                    |
+| ---------------------------------------- | ----------------------------- | ------------------------- |
+| `{"a": 1, "b": 2}`                       | `{"a": 1}`                    | Match                     |
+| `{"a": 1}`                               | `{"a": 1, "b": 2}`            | No match                  |
+| `{"user": {"name": "Alice", "age": 30}}` | `{"user": {"name": "Alice"}}` | Match                     |
+| `[1, 2, 3]`                              | `[3, 1]`                      | Match (order-independent) |
+| `[1, 2]`                                 | `[1, 2, 3]`                   | No match                  |
+| `{"tags": ["a", "b", "c"]}`              | `{"tags": ["b"]}`             | Match                     |
 
 **Use cases:**
 - Check if user has specific role: `contains({"role": "admin"})`
@@ -201,17 +201,17 @@ let filter = Filter::json("metadata",
 
 **Available comparison methods:**
 
-| Method | Description |
-|--------|-------------|
-| `extract_eq(path, value)` | Equal |
-| `extract_ne(path, value)` | Not equal |
-| `extract_gt(path, value)` | Greater than |
-| `extract_lt(path, value)` | Less than |
-| `extract_ge(path, value)` | Greater than or equal |
-| `extract_le(path, value)` | Less than or equal |
-| `extract_in(path, values)` | Value in list |
-| `extract_is_null(path)` | Path doesn't exist or is null |
-| `extract_not_null(path)` | Path exists and is not null |
+| Method                     | Description                   |
+| -------------------------- | ----------------------------- |
+| `extract_eq(path, value)`  | Equal                         |
+| `extract_ne(path, value)`  | Not equal                     |
+| `extract_gt(path, value)`  | Greater than                  |
+| `extract_lt(path, value)`  | Less than                     |
+| `extract_ge(path, value)`  | Greater than or equal         |
+| `extract_le(path, value)`  | Less than or equal            |
+| `extract_in(path, values)` | Value in list                 |
+| `extract_is_null(path)`    | Path doesn't exist or is null |
+| `extract_not_null(path)`   | Path exists and is not null   |
 
 ### HasKey (Path Existence)
 
@@ -260,15 +260,15 @@ let filter = Filter::json("metadata", JsonFilter::has_key("deleted_at")).not();
 
 When extracting JSON values, they're converted to DBMS types:
 
-| JSON Type | DBMS Value |
-|-----------|------------|
-| `null` | `Value::Null` |
+| JSON Type      | DBMS Value       |
+| -------------- | ---------------- |
+| `null`         | `Value::Null`    |
 | `true`/`false` | `Value::Boolean` |
-| Integer number | `Value::Int64` |
-| Float number | `Value::Decimal` |
-| String | `Value::Text` |
-| Array | `Value::Json` |
-| Object | `Value::Json` |
+| Integer number | `Value::Int64`   |
+| Float number   | `Value::Decimal` |
+| String         | `Value::Text`    |
+| Array          | `Value::Json`    |
+| Object         | `Value::Json`    |
 
 **Comparison examples:**
 

--- a/docs/reference/migrations.md
+++ b/docs/reference/migrations.md
@@ -116,9 +116,20 @@ pub enum DataTypeSnapshot {
     Date = 0x40, Datetime = 0x41,
     Blob = 0x50, Text = 0x51, Uuid = 0x52,
     Json = 0x60,
-    Custom(String) = 0xF0,              // name-keyed
+    Custom { tag: String, wire_size: WireSize } = 0xF0,
+}
+
+pub enum WireSize {
+    Fixed(u32),       // column occupies exactly N bytes
+    LengthPrefixed,   // body preceded by 2-byte LE length prefix
 }
 ```
+
+`WireSize` is derived at compile time from the custom type's `Encode::SIZE`:
+`DataSize::Fixed(n)` → `WireSize::Fixed(n)`, `DataSize::Dynamic` →
+`WireSize::LengthPrefixed`. The migration codec uses it to slice column
+bytes during a snapshot-driven rewrite without invoking the user's
+`Encode::decode` impl.
 
 **Stability rules:**
 
@@ -156,7 +167,7 @@ For each compiled column:
    - Types differ and neither applies → `MigrationError::IncompatibleType`.
    - Any constraint flag changed → `AlterColumn { changes }`.
 
-Stored columns not matched by any compiled column (directly or via `renamed_from`) → `DropColumn`. Compiled columns not matched → `AddColumn`. If non-nullable, the planner requires either `#[default = ...]` or `Migrate::default_value` returning `Some`, otherwise `MigrationError::MissingDefault`.
+Stored columns not matched by any compiled column (directly or via `renamed_from`) → `DropColumn`. Compiled columns not matched → `AddColumn`. If non-nullable, the planner requires either `#[default = ...]` or `Migrate::default_value` returning `Some`, otherwise `MigrationError::DefaultMissing`.
 
 **Index diff:**
 
@@ -298,7 +309,7 @@ where
 {
     /// Dynamic default for AddColumn on a non-nullable column.
     /// `None` falls back to the static `#[default]` attribute, else
-    /// MissingDefault.
+    /// DefaultMissing.
     fn default_value(_column: &str) -> Option<Value> { None }
 
     /// Transform a stored value during an incompatible type change.
@@ -345,14 +356,17 @@ dbms.migrate(MigrationPolicy { allow_destructive: true })?;
 
 `DbmsError::Migration(MigrationError)` covers the full migration pipeline:
 
-| Variant               | When                                                                                   |
-| --------------------- | -------------------------------------------------------------------------------------- |
-| `SchemaDrift`         | CRUD called while `drift == true`. Call `migrate(policy)` first.                       |
-| `IncompatibleType`    | Type change is neither in the widening whitelist nor handled by `transform_column`.    |
-| `MissingDefault`      | `AddColumn` on a non-nullable column without `#[default]` or `default_value` override. |
-| `ConstraintViolation` | Tightening op found data that violates the new constraint.                             |
-| `DestructiveOpDenied` | Planner emitted `DropTable` / `DropColumn` while `allow_destructive` is `false`.       |
-| `TransformAborted`    | User `transform_column` impl returned `Err`.                                           |
+| Variant                  | When                                                                                              |
+| ------------------------ | ------------------------------------------------------------------------------------------------- |
+| `SchemaDrift`            | CRUD called while `drift == true`. Call `migrate(policy)` first.                                  |
+| `IncompatibleType`       | Type change is neither in the widening whitelist nor handled by `transform_column`.               |
+| `DefaultMissing`         | `AddColumn` on a non-nullable column without `#[default]` or `default_value` override.            |
+| `ConstraintViolation`    | Tightening op found data that violates the new constraint.                                        |
+| `DestructiveOpDenied`    | Planner emitted `DropTable` / `DropColumn` while `allow_destructive` is `false`.                  |
+| `TransformAborted`       | User `transform_column` impl returned `Err`.                                                      |
+| `WideningIncompatible`   | `WidenColumn` op falls outside the widening whitelist (and no `transform_column` impl handled it). |
+| `TransformReturnedNone`  | `Migrate::transform_column` returned `Ok(None)` while a transform was required.                   |
+| `ForeignKeyViolation`    | Add-FK tightening found a row whose value is absent from the target table's column.               |
 
 See the [Migration Errors section in the errors reference](./errors.md#migration-errors) for matching examples and remediation.
 

--- a/docs/reference/migrations.md
+++ b/docs/reference/migrations.md
@@ -235,12 +235,12 @@ All three writes live in the same journal session as the data rewrites, so parti
 
 Auto-applied without user code. The framework rewrites records in place.
 
-| From → To             | Semantics              |
-| --------------------- | ---------------------- |
-| `IntN` → `IntM`, M > N | sign-extend            |
-| `UintN` → `UintM`, M > N | zero-extend          |
-| `UintN` → `IntM`, M > N | zero-extend into signed |
-| `Float32` → `Float64` | widen                  |
+| From → To                | Semantics               |
+| ------------------------ | ----------------------- |
+| `IntN` → `IntM`, M > N   | sign-extend             |
+| `UintN` → `UintM`, M > N | zero-extend             |
+| `UintN` → `IntM`, M > N  | zero-extend into signed |
+| `Float32` → `Float64`    | widen                   |
 
 Everything else (narrowing, sign flips, int↔float, int↔text, etc.) falls through to `TransformColumn` or errors with `MigrationError::IncompatibleType`.
 
@@ -345,14 +345,14 @@ dbms.migrate(MigrationPolicy { allow_destructive: true })?;
 
 `DbmsError::Migration(MigrationError)` covers the full migration pipeline:
 
-| Variant                | When                                                                                    |
-| ---------------------- | --------------------------------------------------------------------------------------- |
-| `SchemaDrift`          | CRUD called while `drift == true`. Call `migrate(policy)` first.                        |
-| `IncompatibleType`     | Type change is neither in the widening whitelist nor handled by `transform_column`.     |
-| `MissingDefault`       | `AddColumn` on a non-nullable column without `#[default]` or `default_value` override.  |
-| `ConstraintViolation`  | Tightening op found data that violates the new constraint.                              |
-| `DestructiveOpDenied`  | Planner emitted `DropTable` / `DropColumn` while `allow_destructive` is `false`.        |
-| `TransformAborted`     | User `transform_column` impl returned `Err`.                                            |
+| Variant               | When                                                                                   |
+| --------------------- | -------------------------------------------------------------------------------------- |
+| `SchemaDrift`         | CRUD called while `drift == true`. Call `migrate(policy)` first.                       |
+| `IncompatibleType`    | Type change is neither in the widening whitelist nor handled by `transform_column`.    |
+| `MissingDefault`      | `AddColumn` on a non-nullable column without `#[default]` or `default_value` override. |
+| `ConstraintViolation` | Tightening op found data that violates the new constraint.                             |
+| `DestructiveOpDenied` | Planner emitted `DropTable` / `DropColumn` while `allow_destructive` is `false`.       |
+| `TransformAborted`    | User `transform_column` impl returned `Err`.                                           |
 
 See the [Migration Errors section in the errors reference](./errors.md#migration-errors) for matching examples and remediation.
 

--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -71,21 +71,21 @@ Use `Query::builder()` to obtain a `QueryBuilder`.
 
 ### Field Selection
 
-| Method          | Effect                                 |
-|-----------------|----------------------------------------|
-| `.all()`        | Selects all columns (`Select::All`)    |
-| `.field(name)`  | Adds a single column to the selection  |
-| `.fields(iter)` | Adds multiple columns                  |
+| Method          | Effect                                |
+| --------------- | ------------------------------------- |
+| `.all()`        | Selects all columns (`Select::All`)   |
+| `.field(name)`  | Adds a single column to the selection |
+| `.fields(iter)` | Adds multiple columns                 |
 
 The primary key is always included by `Database::select::<T>` even when not explicitly listed.
 
 ### Filters
 
-| Method                    | Effect                                     |
-|---------------------------|--------------------------------------------|
-| `.filter(Option<Filter>)` | Replaces the current filter                |
-| `.and_where(Filter)`      | Combines with existing filter using `AND`  |
-| `.or_where(Filter)`       | Combines with existing filter using `OR`   |
+| Method                    | Effect                                    |
+| ------------------------- | ----------------------------------------- |
+| `.filter(Option<Filter>)` | Replaces the current filter               |
+| `.and_where(Filter)`      | Combines with existing filter using `AND` |
+| `.or_where(Filter)`       | Combines with existing filter using `OR`  |
 
 See [Filters in the Querying Guide](../guides/querying.md#filters) and
 [JSON Filters](./json.md) for the full filter API.
@@ -93,7 +93,7 @@ See [Filters in the Querying Guide](../guides/querying.md#filters) and
 ### Joins
 
 | Method                                    | Join type |
-|-------------------------------------------|-----------|
+| ----------------------------------------- | --------- |
 | `.inner_join(table, left_col, right_col)` | INNER     |
 | `.left_join(table, left_col, right_col)`  | LEFT      |
 | `.right_join(table, left_col, right_col)` | RIGHT     |
@@ -156,7 +156,7 @@ and aggregate results.
 ### Ordering
 
 | Method                   | Effect                              |
-|--------------------------|-------------------------------------|
+| ------------------------ | ----------------------------------- |
 | `.order_by_asc(column)`  | Appends ascending sort by `column`  |
 | `.order_by_desc(column)` | Appends descending sort by `column` |
 
@@ -166,7 +166,7 @@ ties from earlier keys.
 ### Pagination
 
 | Method           | Effect                              |
-|------------------|-------------------------------------|
+| ---------------- | ----------------------------------- |
 | `.limit(usize)`  | Caps the number of records returned |
 | `.offset(usize)` | Skips the first N records           |
 
@@ -192,14 +192,14 @@ pub enum AggregateFunction {
 
 Describes one aggregate function to compute over a group of rows.
 
-| Variant         | SQL equivalent  | Notes                                                                         |
-| --------------- | --------------- | ----------------------------------------------------------------------------- |
-| `Count(None)`   | `COUNT(*)`      | Counts every row in the group                                                 |
-| `Count(Some(c))`| `COUNT(c)`      | Counts non-null values of column `c`                                          |
-| `Sum(c)`        | `SUM(c)`        | Sum of `c` across the group                                                   |
-| `Avg(c)`        | `AVG(c)`        | Arithmetic mean of `c`                                                        |
-| `Min(c)`        | `MIN(c)`        | Minimum value of `c`                                                          |
-| `Max(c)`        | `MAX(c)`        | Maximum value of `c`                                                          |
+| Variant          | SQL equivalent | Notes                                |
+| ---------------- | -------------- | ------------------------------------ |
+| `Count(None)`    | `COUNT(*)`     | Counts every row in the group        |
+| `Count(Some(c))` | `COUNT(c)`     | Counts non-null values of column `c` |
+| `Sum(c)`         | `SUM(c)`       | Sum of `c` across the group          |
+| `Avg(c)`         | `AVG(c)`       | Arithmetic mean of `c`               |
+| `Min(c)`         | `MIN(c)`       | Minimum value of `c`                 |
+| `Max(c)`         | `MAX(c)`       | Maximum value of `c`                 |
 
 ### `AggregatedRow`
 
@@ -265,24 +265,24 @@ planning time (before any rows are scanned) so callers fail fast.
 
 ### Aggregate-specific (`Database::aggregate`)
 
-| Condition                                       | Variant                                  |
-| ----------------------------------------------- | ---------------------------------------- |
-| `SUM` or `AVG` references a non-numeric column  | `InvalidQuery("aggregate requires numeric column: '<col>'")` |
-| Aggregate references a column not on the table  | `UnknownColumn(<col>)`                   |
-| `GROUP BY` references a column not on the table | `UnknownColumn(<col>)`                   |
+| Condition                                       | Variant                                                                  |
+| ----------------------------------------------- | ------------------------------------------------------------------------ |
+| `SUM` or `AVG` references a non-numeric column  | `InvalidQuery("aggregate requires numeric column: '<col>'")`             |
+| Aggregate references a column not on the table  | `UnknownColumn(<col>)`                                                   |
+| `GROUP BY` references a column not on the table | `UnknownColumn(<col>)`                                                   |
 | `HAVING` references unknown column or `agg{N}`  | `InvalidQuery("HAVING references unknown column or aggregate: '<col>'")` |
-| `ORDER BY` references unknown `agg{N}`          | `InvalidQuery("ORDER BY references unknown aggregate output: '<col>'")` |
-| `LIKE` used inside a `HAVING` clause            | `InvalidQuery("LIKE is not supported in HAVING")` |
-| `JSON` filter used inside a `HAVING` clause     | `InvalidQuery("JSON filters are not supported in HAVING")` |
-| Query carries `joins` on an aggregate call      | `InvalidQuery("joins are not supported in aggregate queries")` |
+| `ORDER BY` references unknown `agg{N}`          | `InvalidQuery("ORDER BY references unknown aggregate output: '<col>'")`  |
+| `LIKE` used inside a `HAVING` clause            | `InvalidQuery("LIKE is not supported in HAVING")`                        |
+| `JSON` filter used inside a `HAVING` clause     | `InvalidQuery("JSON filters are not supported in HAVING")`               |
+| Query carries `joins` on an aggregate call      | `InvalidQuery("joins are not supported in aggregate queries")`           |
 | Query carries `eager_relations` on an aggregate | `InvalidQuery("eager relations are not supported in aggregate queries")` |
 
 ### Non-aggregate select paths
 
-| Condition                                               | Variant                       |
-| ------------------------------------------------------- | ----------------------------- |
+| Condition                                                             | Variant                                               |
+| --------------------------------------------------------------------- | ----------------------------------------------------- |
 | `group_by` or `having` set on `select` / `select_raw` / `select_join` | `AggregateClauseInSelect` (use `Database::aggregate`) |
-| Query carries `joins` on a typed `select::<T>` call     | `JoinInsideTypedSelect`       |
+| Query carries `joins` on a typed `select::<T>` call                   | `JoinInsideTypedSelect`                               |
 
 ---
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -73,12 +73,12 @@ pub struct User {
 }
 ```
 
-| Derive | Required | Purpose |
-|--------|----------|---------|
-| `Table` | Yes | Generates table schema and related types |
-| `Clone` | Yes | Required by the macro system |
-| `Debug` | Recommended | Useful for debugging |
-| `PartialEq`, `Eq` | Recommended | Useful for comparisons in tests |
+| Derive            | Required    | Purpose                                  |
+| ----------------- | ----------- | ---------------------------------------- |
+| `Table`           | Yes         | Generates table schema and related types |
+| `Clone`           | Yes         | Required by the macro system             |
+| `Debug`           | Recommended | Useful for debugging                     |
+| `PartialEq`, `Eq` | Recommended | Useful for comparisons in tests          |
 
 > **Note:** For IC canister usage, also add `CandidType` and `Deserialize` derives plus the `#[candid]` attribute. See the [IC Schema Reference](../ic/reference/schema.md).
 
@@ -164,12 +164,12 @@ pub struct User {
 
 **Choosing the right type:**
 
-| Type | Max Records |
-|------|-------------|
-| `Uint32` | ~4.3 billion |
+| Type     | Max Records       |
+| -------- | ----------------- |
+| `Uint32` | ~4.3 billion      |
 | `Uint64` | ~18.4 quintillion |
-| `Int32` | ~2.1 billion |
-| `Int64` | ~9.2 quintillion |
+| `Int32`  | ~2.1 billion      |
+| `Int64`  | ~9.2 quintillion  |
 
 > **Tip:** `Uint64` is recommended for most use cases. Only use smaller types when storage space is critical and you are certain the record count will stay within bounds.
 
@@ -290,11 +290,11 @@ pub struct Post {
 
 **Attribute parameters:**
 
-| Parameter | Description |
-|-----------|-------------|
-| `entity` | Rust struct name of the referenced table |
-| `table` | Table name (from `#[table = "..."]`) |
-| `column` | Column name in the referenced table |
+| Parameter | Description                              |
+| --------- | ---------------------------------------- |
+| `entity`  | Rust struct name of the referenced table |
+| `table`   | Table name (from `#[table = "..."]`)     |
+| `column`  | Column name in the referenced table      |
 
 **Nullable foreign key:**
 
@@ -596,13 +596,13 @@ impl Migrate for Event {
 
 **Trait contract:**
 
-| Method | Returns | Effect |
-| ------ | ------- | ------ |
-| `default_value(column)` | `Some(v)` | Use `v` for `AddColumn` on `column`. |
-| `default_value(column)` | `None` | Fall back to `#[default = ...]`, else `MigrationError::MissingDefault`. |
-| `transform_column(column, old)` | `Ok(Some(v))` | Replace stored value with `v`. |
-| `transform_column(column, old)` | `Ok(None)` | No transform; framework errors with `MigrationError::IncompatibleType` unless the type change is a whitelisted widening. |
-| `transform_column(column, old)` | `Err(_)` | Abort the migration; the journaled session rolls back. |
+| Method                          | Returns       | Effect                                                                                                                   |
+| ------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `default_value(column)`         | `Some(v)`     | Use `v` for `AddColumn` on `column`.                                                                                     |
+| `default_value(column)`         | `None`        | Fall back to `#[default = ...]`, else `MigrationError::MissingDefault`.                                                  |
+| `transform_column(column, old)` | `Ok(Some(v))` | Replace stored value with `v`.                                                                                           |
+| `transform_column(column, old)` | `Ok(None)`    | No transform; framework errors with `MigrationError::IncompatibleType` unless the type change is a whitelisted widening. |
+| `transform_column(column, old)` | `Err(_)`      | Abort the migration; the journaled session rolls back.                                                                   |
 
 > **Note:** Without `#[migrate]`, do **not** write `impl Migrate for T {}` yourself — the macro already emitted one and you would get a duplicate-impl error.
 

--- a/wit/dbms.wit
+++ b/wit/dbms.wit
@@ -112,6 +112,18 @@ interface types {
     // `wasm_dbms_api::dbms::table::schema::snapshot`. Used by the
     // `has-drift`, `pending-migrations`, and `migrate` entry points.
 
+    /// On-disk wire layout descriptor for a custom-typed column.
+    variant wire-size {
+        fixed(u32),
+        length-prefixed,
+    }
+
+    /// User-defined custom data type identifier + wire layout.
+    record custom-data-type-snapshot {
+        tag: string,
+        wire-size: wire-size,
+    }
+
     /// Stable, tag-keyed encoding of a column data type. Discriminants are
     /// part of the on-disk format and must not be reused or reordered.
     variant data-type-snapshot {
@@ -133,7 +145,7 @@ interface types {
         text,
         uuid,
         json,
-        custom(string),
+        custom(custom-data-type-snapshot),
     }
 
     /// `ON DELETE` referential action.

--- a/wit/dbms.wit
+++ b/wit/dbms.wit
@@ -106,6 +106,149 @@ interface types {
 
     type transaction-id = u64;
 
+    // ── Schema migrations ───────────────────────────────────────────────
+    //
+    // Mirrors `wasm_dbms_api::dbms::migration` and the snapshot types in
+    // `wasm_dbms_api::dbms::table::schema::snapshot`. Used by the
+    // `has-drift`, `pending-migrations`, and `migrate` entry points.
+
+    /// Stable, tag-keyed encoding of a column data type. Discriminants are
+    /// part of the on-disk format and must not be reused or reordered.
+    variant data-type-snapshot {
+        int8,
+        int16,
+        int32,
+        int64,
+        uint8,
+        uint16,
+        uint32,
+        uint64,
+        float32,
+        float64,
+        decimal,
+        boolean,
+        date,
+        datetime,
+        blob,
+        text,
+        uuid,
+        json,
+        custom(string),
+    }
+
+    /// `ON DELETE` referential action.
+    enum on-delete-snapshot { restrict, cascade }
+
+    /// Foreign-key reference attached to a column.
+    record foreign-key-snapshot {
+        table: string,
+        column: string,
+        on-delete: on-delete-snapshot,
+    }
+
+    /// Snapshot of a single column definition.
+    record column-snapshot {
+        name: string,
+        data-type: data-type-snapshot,
+        nullable: bool,
+        auto-increment: bool,
+        unique: bool,
+        primary-key: bool,
+        foreign-key: option<foreign-key-snapshot>,
+        default: option<value>,
+    }
+
+    /// Snapshot of a secondary index.
+    record index-snapshot {
+        columns: list<string>,
+        unique: bool,
+    }
+
+    /// Snapshot of a complete table schema.
+    record table-schema-snapshot {
+        version: u8,
+        name: string,
+        primary-key: string,
+        alignment: u32,
+        columns: list<column-snapshot>,
+        indexes: list<index-snapshot>,
+    }
+
+    /// Foreign-key delta inside `column-changes`. Mirrors the inner
+    /// `Option<ForeignKeySnapshot>` of `ColumnChanges::foreign_key`:
+    /// `none` = no change, `some(drop)` = drop, `some(set(fk))` = add/replace.
+    variant foreign-key-change {
+        drop,
+        set(foreign-key-snapshot),
+    }
+
+    /// Constraint-flag deltas for `migration-op::alter-column`.
+    record column-changes {
+        nullable: option<bool>,
+        unique: option<bool>,
+        auto-increment: option<bool>,
+        primary-key: option<bool>,
+        foreign-key: option<foreign-key-change>,
+    }
+
+    /// Single atomic migration step produced by the planner.
+    variant migration-op {
+        create-table(create-table-op),
+        drop-table(string),
+        add-column(add-column-op),
+        drop-column(drop-column-op),
+        rename-column(rename-column-op),
+        alter-column(alter-column-op),
+        widen-column(type-change-op),
+        transform-column(type-change-op),
+        add-index(index-op),
+        drop-index(index-op),
+    }
+
+    record create-table-op {
+        name: string,
+        schema: table-schema-snapshot,
+    }
+
+    record add-column-op {
+        table: string,
+        column: column-snapshot,
+    }
+
+    record drop-column-op {
+        table: string,
+        column: string,
+    }
+
+    record rename-column-op {
+        table: string,
+        old: string,
+        new: string,
+    }
+
+    record alter-column-op {
+        table: string,
+        column: string,
+        changes: column-changes,
+    }
+
+    record type-change-op {
+        table: string,
+        column: string,
+        old-type: data-type-snapshot,
+        new-type: data-type-snapshot,
+    }
+
+    record index-op {
+        table: string,
+        index: index-snapshot,
+    }
+
+    /// Caller policy gating destructive ops.
+    record migration-policy {
+        allow-destructive: bool,
+    }
+
     /// Mirrors `wasm_dbms_api::DbmsError` and its inner variants. Detailed
     /// messages preserve the source `QueryError` / `TableError` string for
     /// host-side diagnostics.
@@ -156,6 +299,8 @@ interface database {
         delete-behavior,
         aggregate-function,
         aggregated-row,
+        migration-op,
+        migration-policy,
     };
 
     /// Runs a `SELECT` against `table`, returning raw rows.
@@ -194,6 +339,20 @@ interface database {
     begin-transaction: func() -> result<transaction-id, dbms-error>;
     commit: func(tx: transaction-id) -> result<_, dbms-error>;
     rollback: func(tx: transaction-id) -> result<_, dbms-error>;
+
+    /// Returns `true` iff the compiled schema differs from the snapshots
+    /// persisted in stable memory. Cached on the DBMS context after the
+    /// first call.
+    has-drift: func() -> result<bool, dbms-error>;
+
+    /// Returns the migration ops needed to bring the on-disk schema in line
+    /// with the compiled schema. Does not apply anything.
+    pending-migrations: func() -> result<list<migration-op>, dbms-error>;
+
+    /// Plans, validates, sorts, and applies the diff atomically. On success
+    /// the drift flag is cleared; on failure the journal rolls back and the
+    /// flag stays set.
+    migrate: func(policy: migration-policy) -> result<_, dbms-error>;
 }
 
 world dbms {


### PR DESCRIPTION
## Summary

Closes #91. Lands `AddColumn`, `DropColumn`, `RenameColumn`, `WidenColumn`, and `TransformColumn` through a new snapshot-driven record (de)serializer that reads/writes records under any `TableSchemaSnapshot` independent of the compile-time `T`.

- New `migration::codec` module with `decode_record_by_snapshot` / `encode_record_by_snapshot`, dispatching per `DataTypeSnapshot` variant.
- `DataTypeSnapshot::Custom` now carries `CustomDataTypeSnapshot { tag, wire_size: WireSize::{Fixed(u32) | LengthPrefixed} }`, derived at compile time from `<T as Encode>::SIZE` via `WireSize::from_data_size`. The variant is boxed in `DataTypeSnapshot` to keep `MigrationError` under clippy's `result_large_err` threshold.
- New `RawTableReader` + `insert_raw` / `read_raw_at` / `delete_raw` on `TableRegistry` (plus `zero_raw` on `MemoryAccess` and the journaled writer).
- `migration::apply` `rewrite_table` helper drives per-op rewrite + index rebuild inside the existing journal session.
- New `widen.rs` whitelist (`IntN→IntM`, `UintN→UintM`, `UintN→IntM`, `Float32→Float64`) used by `WidenColumn`.
- Add-FK tightening now validates against existing rows.
- New `MigrationError` variants: `WideningIncompatible`, `TransformReturnedNone`, `ForeignKeyViolation`. `MissingDefault` renamed to `DefaultMissing`. `DataRewriteUnsupported` removed.
- WIT surface gains `wire-size` + `custom-data-type-snapshot` records.
- Docs (migrations reference + guide, errors reference, IC migrations guide) updated.

## Test plan

- [ ] `just build_all`
- [ ] `cargo test --workspace --exclude wasm-dbms-example-guest --exclude example --lib`
- [ ] `just check_code` (fmt + clippy under workspace, no `--all-targets`)
- [ ] PocketIC migration tests still pass: `just integration_test migrations`
- [ ] Manual smoke: drift detection unaffected on a fresh DB

Engine coverage: 22 tests in `database::migration::apply::tests` covering per-op happy path, default resolution, multi-op atomic apply, widening incompatibility rollback, transform-returned-none rollback, add-FK violation rollback, index rebuild after column rewrite. Codec round-trip tests cover every `DataTypeSnapshot` variant including `Custom Fixed` and `LengthPrefixed`.